### PR TITLE
Sample app - Delay asking for Push Permissions until enrollment.

### DIFF
--- a/Examples/PushSampleApp/SampleApp/AppDelegate.swift
+++ b/Examples/PushSampleApp/SampleApp/AppDelegate.swift
@@ -48,10 +48,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         rootCoordinator = RootCoordinator(deviceAuthenticator: deviceAuthenticator,
                                           oktaWebAuthenticator: webAuthenticator,
                                           remediationEventsHandler: remediationEventsHandler,
+                                          pushNotificationService: pushNotificationService,
                                           oktaLogger: logger)
         rootCoordinator?.begin(on: window)
-
-        pushNotificationService.requestNotificationsPermissions()
+        
         return true
     }
 

--- a/Examples/PushSampleApp/SampleApp/Extensions+Utils/UserDefaults+Extensions.swift
+++ b/Examples/PushSampleApp/SampleApp/Extensions+Utils/UserDefaults+Extensions.swift
@@ -20,7 +20,9 @@ extension UserDefaults {
     static func clearDeviceToken() {
         UserDefaults.standard.removeObject(forKey: DeviceTokenKey)
     }
-    
+    /*
+     Using UserDefaults to save APNS Device Token. For a production app, a safer storage (e.g. Keychain) is recommended.
+     */
     static func save(deviceToken: Data) {
         UserDefaults.standard.set(deviceToken, forKey: DeviceTokenKey)
     }

--- a/Examples/PushSampleApp/SampleApp/RootCoordinator.swift
+++ b/Examples/PushSampleApp/SampleApp/RootCoordinator.swift
@@ -20,20 +20,22 @@ class RootCoordinator {
     let deviceAuthenticator: DeviceAuthenticatorProtocol
     let oktaWebAuthenticator: OktaWebAuthProtocol
     var remediationEventsHandler: RemediationStepHandlerProtocol
+    let pushNotificationService: PushNotificationService
     var logger: OktaLogger?
     var navController: UINavigationController?
     
-
     static let mainStoryboardName = "MainStoryboard"
 
     init(deviceAuthenticator: DeviceAuthenticatorProtocol,
          oktaWebAuthenticator: OktaWebAuthProtocol,
          remediationEventsHandler: RemediationStepHandlerProtocol,
+         pushNotificationService: PushNotificationService,
          oktaLogger: OktaLogger?) {
         self.deviceAuthenticator = deviceAuthenticator
         self.oktaWebAuthenticator = oktaWebAuthenticator
-        self.logger = oktaLogger
         self.remediationEventsHandler = remediationEventsHandler
+        self.pushNotificationService = pushNotificationService
+        self.logger = oktaLogger
         setupRemediationHandler()
     }
 
@@ -100,7 +102,11 @@ class RootCoordinator {
     
     func beginSettingsFlow() {
         let vc = SettingsViewController.loadFromStoryboard(storyboardName: Self.mainStoryboardName)
-        vc.viewModel = SettingsViewModel(deviceauthenticator: deviceAuthenticator, webAuthenticator: oktaWebAuthenticator, settingsView: vc, logger: logger)
+        let viewModel = SettingsViewModel(deviceauthenticator: deviceAuthenticator, webAuthenticator: oktaWebAuthenticator, pushNotificationService: pushNotificationService, settingsView: vc, logger: logger)
+        pushNotificationService.didEnableRemoteNotifications = { [weak viewModel] in
+            viewModel?.beginEnrollmentIfNeeded()
+        }
+        vc.viewModel = viewModel
         let nav = UINavigationController(rootViewController: vc)
 
         navController?.present(nav, animated: true)


### PR DESCRIPTION
- Previously we were displaying the push permissions prompt right on app launch.
- We should give context when prompting for push. Thus delaying it until user tries to Enroll.