### PR TITLE
OKTA-514972 - TestHarness app crashes while retrieving push challenge

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,9 +6,9 @@ PODS:
     - GRDB.swift (~> 5)
     - OktaJWT (~> 2.3)
     - OktaLogger/FileLogger (~> 1)
-  - GRDB.swift (5.25.0):
-    - GRDB.swift/standard (= 5.25.0)
-  - GRDB.swift/standard (5.25.0)
+  - GRDB.swift (5.26.0):
+    - GRDB.swift/standard (= 5.26.0)
+  - GRDB.swift/standard (5.26.0)
   - OktaJWT (2.3.5)
   - OktaLogger/Core (1.3.8):
     - SwiftLint
@@ -40,7 +40,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   DeviceAuthenticator: c9639a7ee99d41be8f41cb8480b5a57855615bfa
-  GRDB.swift: 39b3ff769afde87a840ced4e3a327d5c6f6a6e4f
+  GRDB.swift: 1395cb3556df6b16ed69dfc74c3886abc75d2825
   OktaJWT: d9934b947fd0742713557b9ab9e1a313d40751cc
   OktaLogger: f92c0fd63642204558cbef3755050cf80b107820
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d

--- a/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
+++ b/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
@@ -49,7 +49,7 @@ public protocol AuthenticatorEnrollmentProtocol {
     ///   - completion: Closure called when the retrieval process has completed
     ///  - Discussion: This method is useful for user-driven activity indicating they would like to remediate a challenge. Examples: User clicks a refresh button, foregrounds the app.
     func retrievePushChallenges(authenticationToken: AuthToken,
-                                allowedClockSkewInSeconds: UInt,
+                                allowedClockSkewInSeconds: Int,
                                 completion: @escaping (Result<[PushChallengeProtocol], DeviceAuthenticatorError>) -> Void)
 
     ///  Delete the enrollment from this device's local storage
@@ -59,7 +59,7 @@ public protocol AuthenticatorEnrollmentProtocol {
 
 public extension AuthenticatorEnrollmentProtocol {
     func retrievePushChallenges(authenticationToken: AuthToken,
-                                allowedClockSkewInSeconds: UInt = 300,
+                                allowedClockSkewInSeconds: Int = 300,
                                 completion: @escaping (Result<[PushChallengeProtocol], DeviceAuthenticatorError>) -> Void) {
         retrievePushChallenges(authenticationToken: authenticationToken,
                                allowedClockSkewInSeconds: allowedClockSkewInSeconds,

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -20,6 +20,7 @@ class RestAPIMock: OktaRestAPI {
     typealias updateAuthenticatorRequestType = (URL, Data, OktaRestAPIToken, @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
     typealias deleteAuthenticatorRequestType = (URL, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
+    typealias pendingChallengeRequestType = (URL, AuthToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
 
     var enrollAuthenticatorRequestHook: enrollAuthenticatorRequestType?
     var downloadOrgIdTypeHook: downloadOrgIdType?
@@ -27,6 +28,7 @@ class RestAPIMock: OktaRestAPI {
     var downloadAuthenticatorMetadataHook: downloadAuthenticatorMetadataType?
     var error: DeviceAuthenticatorError?
     var deleteAuthenticatorRequestHook: deleteAuthenticatorRequestType?
+    var pendingChallengeRequestHook: pendingChallengeRequestType?
 
     override func deleteAuthenticatorRequest(url: URL, token: OktaRestAPIToken, completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
         if let deleteAuthenticatorRequestHook = deleteAuthenticatorRequestHook {
@@ -88,6 +90,14 @@ class RestAPIMock: OktaRestAPI {
             updateAuthenticatorRequestHook(url, data, token, completion)
         } else {
             super.updateAuthenticatorRequest(url: url, data: data, token: token, completion: completion)
+        }
+    }
+
+    override public func pendingChallenge(with orgURL: URL, authenticationToken: AuthToken, completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
+        if let pendingChallengeRequestHook = pendingChallengeRequestHook {
+            pendingChallengeRequestHook(orgURL, authenticationToken, completion)
+        } else {
+            super.pendingChallenge(with: orgURL, authenticationToken: authenticationToken, completion: completion)
         }
     }
 


### PR DESCRIPTION
Implementation changed type for allowedClockSkewInSeconds to Int where protocol still requires UInt. That caused indefinite loop in protocol extension when application attempts to call it