### PR TITLE
CI - Set custom derivedDataPath for testing commands

### DIFF
--- a/.github/workflows/okta_devices.yml
+++ b/.github/workflows/okta_devices.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install pod
       run: pod install
     - name: Build DeviceAuthenticator target
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticator" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean build-for-testing
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticator" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean build-for-testing -derivedDataPath "~/build"
     - name: Unit Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorUnitTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorUnitTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building -derivedDataPath "~/build"
     - name: Functional Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFunctionalTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFunctionalTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building -derivedDataPath "~/build"

--- a/DeviceAuthenticator.xcodeproj/xcshareddata/xcschemes/DeviceAuthenticatorFunctionalTests.xcscheme
+++ b/DeviceAuthenticator.xcodeproj/xcshareddata/xcschemes/DeviceAuthenticatorFunctionalTests.xcscheme
@@ -50,6 +50,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+            BuildableName = "PushSDKTestApp.app"
+            BlueprintName = "PushSDKTestApp"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -57,15 +67,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7FFB600F286A80CF006BC548"
-            BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
-            BlueprintName = "DeviceAuthenticatorFunctionalTests"
-            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/DeviceAuthenticator.xcodeproj/xcshareddata/xcschemes/DeviceAuthenticatorUnitTests.xcscheme
+++ b/DeviceAuthenticator.xcodeproj/xcshareddata/xcschemes/DeviceAuthenticatorUnitTests.xcscheme
@@ -76,6 +76,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+            BuildableName = "PushSDKTestApp.app"
+            BlueprintName = "PushSDKTestApp"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -83,15 +93,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7FFB5FF9286A7F4C006BC548"
-            BuildableName = "DeviceAuthenticatorUnitTests.xctest"
-            BlueprintName = "DeviceAuthenticatorUnitTests"
-            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
According to Github docs:
`Each run keyword represents a new process and shell in the runner environment. When you provide multi-line commands, each line runs in the same shell.`
Which may have caused the flakiness since the derived data folder was wiped out between runs. 
This approach passes a custom derivedDataPath into the xcodebuild command so it persists between steps.