### PR TITLE
Expose public protocols for DeviceSDK

### DIFF
--- a/Sources/DeviceAuthenticator/Networking/HTTPClientProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/HTTPClientProtocol.swift
@@ -13,7 +13,7 @@
 import Foundation
 import OktaLogger
 
-protocol HTTPClientProtocol {
+public protocol HTTPClientProtocol {
 
     /// Current url session
     var currentSession: URLSession { get }

--- a/Sources/DeviceAuthenticator/Networking/HTTPMethod.swift
+++ b/Sources/DeviceAuthenticator/Networking/HTTPMethod.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// HTTP methods enumeration
-enum HTTPMethod: Int {
+public enum HTTPMethod: Int {
     case get, post, put, delete
 
     func toString() -> String {

--- a/Sources/DeviceAuthenticator/Networking/OktaURLRequestProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/OktaURLRequestProtocol.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Abstract interface that represents HTTP request
-@objc protocol URLRequestProtocol {
+@objc public protocol URLRequestProtocol {
     var currentRequest: URLRequest { get }
 
     /**


### PR DESCRIPTION
Needed for this PR.
https://github.com/okta-tardis/okta-devices-swift/pull/435

Changing `OktaHttpClient` to `HTTPClientProtocol` in `OktaAuthenticator` requires these definitions to be made public