### PR TITLE
OKTA-519011 - Test Harness App: Same account can be enrolled twice, one with normal url and another with vanity url

### DIFF
--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
@@ -102,7 +102,7 @@ class OktaSharedSQLite: OktaSharedSQLiteProtocol {
                     sql: "DELETE from EnrolledMethod WHERE enrollmentId = ? AND orgId = ?",
                     arguments: [enrollmentDuplicate.enrollmentId, enrollmentDuplicate.organization.id])
             }
-            try db.execute(sql: "INSERT INTO Enrollment (enrollmentId, orgId, serverErrorCode, orgUrl, userId, username, deviceId, createdTimestamp, updatedTimestamp) VALUES (:enrollmentId, :orgId, :serverErrorCode, :orgUrl, :userId, :username, :deviceId, :createdTimestamp, :updatedTimestamp) ON CONFLICT(userId,orgId) DO UPDATE SET enrollmentId = :enrollmentId, orgId = :orgId, serverErrorCode = :serverErrorCode, orgUrl = :orgUrl, userId = :userId, username = :username, deviceId = :deviceId, updatedTimestamp = :updatedTimestamp", arguments: writeArguments)
+            try db.execute(sql: "INSERT INTO Enrollment (enrollmentId, orgId, serverErrorCode, orgUrl, userId, username, deviceId, createdTimestamp, updatedTimestamp) VALUES (:enrollmentId, :orgId, :serverErrorCode, :orgUrl, :userId, :username, :deviceId, :createdTimestamp, :updatedTimestamp) ON CONFLICT(enrollmentId,orgId) DO UPDATE SET enrollmentId = :enrollmentId, orgId = :orgId, serverErrorCode = :serverErrorCode, orgUrl = :orgUrl, userId = :userId, username = :username, deviceId = :deviceId, updatedTimestamp = :updatedTimestamp", arguments: writeArguments)
 
             // Enrolled factors
 

--- a/Sources/DeviceAuthenticator/Storage/SQLite/schemas/SQLiteSchema_200.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/schemas/SQLiteSchema_200.swift
@@ -26,7 +26,7 @@ class SQLiteSchema_200: SQLiteSchemaProtocol {
     'serverErrorCode' TEXT DEFAULT NULL,
     'createdTimestamp' TEXT DEFAULT NULL,
     'updatedTimestamp' TEXT DEFAULT NULL,
-    UNIQUE (userId, orgId)
+    UNIQUE (enrollmentId, orgId)
     );
 
     CREATE TABLE 'EnrolledMethod' (

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
@@ -243,7 +243,7 @@ class OktaSharedSQLiteTests: XCTestCase {
 
         try? sqlite.storeEnrollment(enrollmentA)
         let enrollmentB = entitiesGenerator.createAuthenticator(orgId: "myOrgId",
-                                                                enrollmentId: "id-2",
+                                                                enrollmentId: "id-1",
                                                                 userId: "user1@hello.world",
                                                                 enrolledFactors: [pushFactor])
         try? sqlite.storeEnrollment(enrollmentB)


### PR DESCRIPTION
SDK doesn't store two accounts because of the constraint in enrollment table: `UNIQUE (userId, orgId)`
Above constrain doesn't look right since it doesn't allow to store enrollments for two different authenticators