### PR TITLE
Add code coverage via xcov and fix GH Actions jobs

### DIFF
--- a/.github/workflows/okta_devices.yml
+++ b/.github/workflows/okta_devices.yml
@@ -7,28 +7,74 @@ on:
     branches: [ master ]
 
 jobs:
-#### Uncomment once we move the code to this public repo.
   SampleApp:
-    runs-on: macos-11
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - name: install pod
       run: cd Examples/PushSampleApp; pod install   
     - name: iOS Push Sample App
-      run: set -o pipefail && xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean build
-  Tests:
-    runs-on: macos-11
+      run: set -o pipefail && xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" clean build
+  BuildDeviceAuthenticator:
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
+      DERIVED_DATA_PATH: "DerivedData"
     steps:
     - uses: actions/checkout@v2
     - name: Install pod
       run: pod install
     - name: Build DeviceAuthenticator target
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticator" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" clean build-for-testing -derivedDataPath "~/build"
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "PushSDKTestApp" -derivedDataPath $DERIVED_DATA_PATH -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" clean build-for-testing -verbose
+    - name: Upload products
+      uses: actions/upload-artifact@v1
+      with:
+        name: Products
+        path: DerivedData/Build/Products
+  UnitTests:
+    runs-on: macos-12
+    env:
+      DERIVED_DATA_PATH: "DerivedData"
+    needs: BuildDeviceAuthenticator
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+    - name: Download products
+      uses: actions/download-artifact@v1
+      with:
+        name: Products
     - name: Unit Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorUnitTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building -derivedDataPath "~/build"
+      #run: set -o pipefail && xcodebuild -only-testing:DeviceAuthenticatorUnitTests -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" -xctestrun $(find . -type f -name "*.xctestrun") -derivedDataPath $DERIVED_DATA_PATH test-without-building
+      run: |
+        mkdir -p DerivedData/Build
+        mv ./Products ./DerivedData/Build
+        set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorUnitTests" -derivedDataPath DerivedData -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" test-without-building
+  FunctionalTests:
+    runs-on: macos-12
+    env:
+      DERIVED_DATA_PATH: "DerivedData"
+    needs: BuildDeviceAuthenticator
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+    - name: Download products
+      uses: actions/download-artifact@v1
+      with:
+        name: Products
+    - name: Set up DerivedData
+      run: |
+        mkdir -p DerivedData/Build
+        mv ./Products DerivedData/Build
     - name: Functional Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFunctionalTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test-without-building -derivedDataPath "~/build"
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFunctionalTests" -derivedDataPath DerivedData -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" test-without-building
+  CodeCoverage:
+    runs-on: macos-12
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+    - name: Install xcov
+      run: gem install xcov
+    - name: Run code coverage for all tests
+      run: |
+        pod install
+        xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticator" -derivedDataPath CodeCov -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" clean build test -quiet
+        xcov -s DeviceAuthenticator -j CodeCov

--- a/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticator.xcscheme
+++ b/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticator.xcscheme
@@ -9,6 +9,20 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
+               BuildableName = "DeviceAuthenticator.framework"
+               BlueprintName = "DeviceAuthenticator"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
@@ -26,8 +40,29 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
+            BuildableName = "DeviceAuthenticator.framework"
+            BlueprintName = "DeviceAuthenticator"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7FFB5FF9286A7F4C006BC548"
+               BuildableName = "DeviceAuthenticatorUnitTests.xctest"
+               BlueprintName = "DeviceAuthenticatorUnitTests"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference
@@ -50,16 +85,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
-            BuildableName = "PushSDKTestApp.app"
-            BlueprintName = "PushSDKTestApp"
-            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -67,6 +92,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
+            BuildableName = "DeviceAuthenticator.framework"
+            BlueprintName = "DeviceAuthenticator"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticatorFunctionalTests.xcscheme
+++ b/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticatorFunctionalTests.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7FFB600F286A80CF006BC548"
+               BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
+               BlueprintName = "DeviceAuthenticatorFunctionalTests"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+               BuildableName = "PushSDKTestApp.app"
+               BlueprintName = "PushSDKTestApp"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7FFB600F286A80CF006BC548"
+               BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
+               BlueprintName = "DeviceAuthenticatorFunctionalTests"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+            BuildableName = "PushSDKTestApp.app"
+            BlueprintName = "PushSDKTestApp"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7FFB600F286A80CF006BC548"
+            BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
+            BlueprintName = "DeviceAuthenticatorFunctionalTests"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticatorUnitTests.xcscheme
+++ b/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/DeviceAuthenticatorUnitTests.xcscheme
@@ -9,28 +9,28 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
-               BuildableName = "DeviceAuthenticator.framework"
-               BlueprintName = "DeviceAuthenticator"
-               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7FFB600F286A80CF006BC548"
-               BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
-               BlueprintName = "DeviceAuthenticatorFunctionalTests"
+               BlueprintIdentifier = "7FFB5FF9286A7F4C006BC548"
+               BuildableName = "DeviceAuthenticatorUnitTests.xctest"
+               BlueprintName = "DeviceAuthenticatorUnitTests"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+               BuildableName = "PushSDKTestApp.app"
+               BlueprintName = "PushSDKTestApp"
                ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -51,16 +51,32 @@
                BlueprintName = "DeviceAuthenticatorUnitTests"
                ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
             </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7FFB600F286A80CF006BC548"
-               BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
-               BlueprintName = "DeviceAuthenticatorFunctionalTests"
-               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
-            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CryptoManagerTests/testEncryptionManager_BasicOperations()">
+               </Test>
+               <Test
+                  Identifier = "DeviceAuthenticatorTests">
+               </Test>
+               <Test
+                  Identifier = "OktaSQLiteEncryptionManagerTests">
+               </Test>
+               <Test
+                  Identifier = "OktaSecureStorageTests">
+               </Test>
+               <Test
+                  Identifier = "OktaSharedSQLiteTests">
+               </Test>
+               <Test
+                  Identifier = "OktaStorageManagerTests">
+               </Test>
+               <Test
+                  Identifier = "TransactionPossessionChallengeBaseTests">
+               </Test>
+               <Test
+                  Identifier = "TransactionTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>
@@ -74,6 +90,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+            BuildableName = "PushSDKTestApp.app"
+            BlueprintName = "PushSDKTestApp"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -84,9 +110,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
-            BuildableName = "DeviceAuthenticator.framework"
-            BlueprintName = "DeviceAuthenticator"
+            BlueprintIdentifier = "7FFB5FF9286A7F4C006BC548"
+            BuildableName = "DeviceAuthenticatorUnitTests.xctest"
+            BlueprintName = "DeviceAuthenticatorUnitTests"
             ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/PushSDKTestApp.xcscheme
+++ b/DeviceAuthenticator.xcworkspace/xcshareddata/xcschemes/PushSDKTestApp.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7FFB5FF9286A7F4C006BC548"
-               BuildableName = "DeviceAuthenticatorUnitTests.xctest"
-               BlueprintName = "DeviceAuthenticatorUnitTests"
+               BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+               BuildableName = "PushSDKTestApp.app"
+               BlueprintName = "PushSDKTestApp"
                ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7FFB5F73285BA94A006BC548"
+            BuildableName = "DeviceAuthenticator.framework"
+            BlueprintName = "DeviceAuthenticator"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -37,32 +48,16 @@
                BlueprintName = "DeviceAuthenticatorUnitTests"
                ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "CryptoManagerTests/testEncryptionManager_BasicOperations()">
-               </Test>
-               <Test
-                  Identifier = "DeviceAuthenticatorTests">
-               </Test>
-               <Test
-                  Identifier = "OktaSQLiteEncryptionManagerTests">
-               </Test>
-               <Test
-                  Identifier = "OktaSecureStorageTests">
-               </Test>
-               <Test
-                  Identifier = "OktaSharedSQLiteTests">
-               </Test>
-               <Test
-                  Identifier = "OktaStorageManagerTests">
-               </Test>
-               <Test
-                  Identifier = "TransactionPossessionChallengeBaseTests">
-               </Test>
-               <Test
-                  Identifier = "TransactionTests">
-               </Test>
-            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7FFB600F286A80CF006BC548"
+               BuildableName = "DeviceAuthenticatorFunctionalTests.xctest"
+               BlueprintName = "DeviceAuthenticatorFunctionalTests"
+               ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+            </BuildableReference>
          </TestableReference>
       </Testables>
    </TestAction>
@@ -93,6 +88,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F8833FB287C763A0034CA5E"
+            BuildableName = "PushSDKTestApp.app"
+            BlueprintName = "PushSDKTestApp"
+            ReferencedContainer = "container:DeviceAuthenticator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
<img width="691" alt="Screen Shot 2022-08-08 at 8 21 53 PM" src="https://user-images.githubusercontent.com/101673188/183536515-512c6cb0-e3e6-4c9a-8089-5951280cac44.png">

3 jobs run in parallel:
- SampleApp
- CodeCoverage
- BuildDeviceAuthenticator target with `build-for-testing` and runs Unit Test and Functional tests with `test-without-building`