### PR TITLE
Fixed Secure Enclave availability check

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
@@ -141,7 +141,7 @@ class OktaDeviceModelBuilder {
         var additionalParameters: [String: _OktaCodableArbitaryType] = [:]
         additionalParameters["okta:kpr"] = .string(OktaEnvironment.canUseSecureEnclave() ? "HARDWARE" : "SOFTWARE")
         #if os(iOS)
-        additionalParameters["okta:isFipsCompliant"] = .bool(OktaEnvironment.isSecureEnclaveAvailable())
+        additionalParameters["okta:isFipsCompliant"] = .bool(OktaEnvironment.canUseSecureEnclave())
         #endif
 
         if let secKey = try? cryptoManager.generate(keyPairWith: .ES256,

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -428,7 +428,7 @@ class OktaTransactionEnroll: OktaTransaction {
 
         additionalParameters["okta:kpr"] = .string(keyProtection)
         #if os(iOS)
-        additionalParameters["okta:isFipsCompliant"] = .bool(OktaEnvironment.isSecureEnclaveAvailable())
+        additionalParameters["okta:isFipsCompliant"] = .bool(OktaEnvironment.canUseSecureEnclave())
         #endif
 
         guard let jwk = try jwkGenerator.generate(for: secKey,

--- a/Sources/DeviceAuthenticator/Utils/OktaEnvironment.swift
+++ b/Sources/DeviceAuthenticator/Utils/OktaEnvironment.swift
@@ -39,18 +39,6 @@ class OktaEnvironment {
 #endif
     }
 
-    class func isSecureEnclaveAvailable() -> Bool {
-#if os(iOS)
-    #if targetEnvironment(simulator)
-        return false
-    #else
-        return SecureEnclave.isAvailable
-    #endif
-#else
-        return false
-#endif
-    }
-
     class func hasUserVerificationCapabilites(laContext: LAContext = LAContext()) -> (result: Bool, error: NSError?) {
         var error: NSError?
         let result = laContext.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -59,7 +59,7 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         XCTAssertNotNil(deviceSignalsModel.screenLockType)
         #else
         XCTAssertEqual(deviceSignalsModel.clientInstanceKey!["okta:isFipsCompliant"],
-                       _OktaCodableArbitaryType.bool(OktaEnvironment.isSecureEnclaveAvailable()))
+                       _OktaCodableArbitaryType.bool(OktaEnvironment.canUseSecureEnclave()))
         XCTAssertNil(deviceSignalsModel.diskEncryptionType)
         XCTAssertEqual(deviceSignalsModel.screenLockType, BasicSignalsHelper().screenLockType)
         #endif

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
@@ -645,9 +645,9 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
         if let pushRequestModel = enrolledFactors?.first(where: { $0.methodType == .push })?.requestModel {
             XCTAssertNil(pushRequestModel.isFipsCompliant)
             XCTAssertEqual(pushRequestModel.keys?.proofOfPossession?["okta:isFipsCompliant"],
-                           .bool(OktaEnvironment.isSecureEnclaveAvailable()))
+                           .bool(OktaEnvironment.canUseSecureEnclave()))
             XCTAssertEqual(pushRequestModel.keys?.userVerification?.value()?["okta:isFipsCompliant"],
-                           .bool(OktaEnvironment.isSecureEnclaveAvailable()))
+                           .bool(OktaEnvironment.canUseSecureEnclave()))
         } else {
             XCTFail()
         }


### PR DESCRIPTION
Use method based on biometry check instead of SecureEnclave.isAvailable.
Motivation: SecureEnclave.isAvailable does not give reliable result.