### PR TITLE
Improve CI by building once for tests and code coverage

### DIFF
--- a/.github/workflows/okta_devices.yml
+++ b/.github/workflows/okta_devices.yml
@@ -14,32 +14,79 @@ jobs:
     - name: install pod
       run: cd Examples/PushSampleApp; pod install   
     - name: iOS Push Sample App
-      run: set -o pipefail && xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" clean build
+      run: xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" clean build
+  Build:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install pod
+      run: pod install
+    - name: Build for testing and code cov
+      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" -derivedDataPath DerivedData build-for-testing | xcpretty
+    - name: Upload products
+      uses: actions/upload-artifact@v1
+      with:
+        name: Products
+        path: DerivedData/Build/Products
   UnitTests:
     runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install pod
-      run: pod install
-    - name: Unit Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorUnitTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" test | xcpretty
-  FunctionalTests:
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install pod
-      run: pod install
-    - name: Functional Tests
-      run: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFunctionalTests" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" test | xcpretty
-  CodeCoverage:
-    runs-on: macos-12
+    needs: Build
     steps:
     - name: Checkout project
       uses: actions/checkout@v2
-    - name: Install xcov
-      run: gem install xcov
-    - name: Run code coverage for all tests
+    - name: Download products
+      uses: actions/download-artifact@v1
+      with:
+        name: Products
+    - name: Unit Tests
       run: |
-        pod install
-        xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -derivedDataPath CodeCov -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" -enableCodeCoverage YES clean build test -quiet
-        xcov -s DeviceAuthenticatorFramework -j CodeCov
+        mkdir -p DerivedData/Build
+        mv ./Products ./DerivedData/Build
+        set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorUnitTests -enableCodeCoverage YES | xcpretty
+    - name: Upload Test logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: UTLogs
+        path: DerivedData/Logs/Test
+  FunctionalTests:
+    runs-on: macos-12
+    needs: Build
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+    - name: Download products
+      uses: actions/download-artifact@v1
+      with:
+        name: Products
+    - name: Functional Tests
+      run: |
+        mkdir -p DerivedData/Build
+        mv ./Products ./DerivedData/Build
+        set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorFunctionalTests -enableCodeCoverage YES | xcpretty
+    - name: Upload Test logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: FTLogs
+        path: DerivedData/Logs/Test
+  CodeCoverage:
+    runs-on: macos-12
+    needs: [UnitTests,FunctionalTests]
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v2
+    - name: Download Unit Tests Logs
+      uses: actions/download-artifact@v1
+      with:
+        name: UTLogs
+    - name: Download Functional Tests Logs
+      uses: actions/download-artifact@v1
+      with:
+        name: FTLogs
+    - name: Generate Code Coverage
+      run: |
+        gem install xcov
+        mkdir -p DerivedData/Logs/Test
+        cp -r ./UTLogs/* ./DerivedData/Logs/Test
+        cp -r ./FTLogs/* ./DerivedData/Logs/Test
+        xcov -s DeviceAuthenticatorFramework -j DerivedData
+  


### PR DESCRIPTION
Build project with `build-for-testing` and reuse artifacts between Unit Tests, Functional Tests and Code Coverage with xcov