### PR TITLE
Don't add kSecUseDataProtectionKeychain when generating EC key on iOS.

### DIFF
--- a/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
@@ -183,9 +183,12 @@ class OktaCryptoManager: OktaSharedCryptoProtocol {
 
     func baseQuery(with tag: String) -> [NSObject: Any] {
         var query: [NSObject: Any] = [kSecClass: kSecClassKey, kSecAttrApplicationTag: tag]
-        if #available(macOS 10.15, iOS 13.0, *) {
+        #if os(macOS)
+        if #available(macOS 10.15, *) {
+            logger.error(eventName: "CRYPTO", message: "Adding kSecUseDataProtectionKeychain key")
             query[kSecUseDataProtectionKeychain] = kCFBooleanTrue
         }
+        #endif
         return query
     }
 }

--- a/Sources/DeviceAuthenticator/Storage/OktaSecureStorage.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaSecureStorage.swift
@@ -153,9 +153,11 @@ class OktaSecureStorage {
             let searchQuery = findQuery(for: key, accessGroup: accessGroup)
             query.removeValue(forKey: kSecClass as String)
             query.removeValue(forKey: kSecAttrService as String)
-            if #available(macOS 10.15, iOS 13.0, *) {
+            #if os(macOS)
+            if #available(macOS 10.15, *) {
                 query.removeValue(forKey: kSecUseDataProtectionKeychain as String)
             }
+            #endif
             errorCode = SecItemUpdate(searchQuery as CFDictionary, query as CFDictionary)
             if errorCode != noErr {
                 throw NSError(domain: OktaSecureStorage.keychainErrorDomain, code: Int(errorCode), userInfo: nil)
@@ -319,9 +321,11 @@ class OktaSecureStorage {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword as String,
             kSecAttrService as String: "OktaSecureStorage"]
-        if #available(macOS 10.15, iOS 13.0, *) {
+        #if os(macOS)
+        if #available(macOS 10.15, *) {
             query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
         }
+        #endif
         return query
     }
 

--- a/Tests/DeviceAuthenticatorUnitTests/CryptoManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/CryptoManagerTests.swift
@@ -39,9 +39,11 @@ class CryptoManagerTests: XCTestCase {
         var expectedPrivateKeyDeleteAttr = [kSecAttrLabel: privateKeyInternalTag as Any,
                                             kSecAttrKeyClass: kSecAttrKeyClassPrivate,
                                             kSecClass: kSecClassKey]
-        if #available(macOS 10.15, iOS 13.0, *) {
+        #if os(macOS)
+        if #available(macOS 10.15, *) {
             expectedPrivateKeyDeleteAttr[kSecUseDataProtectionKeychain] = kCFBooleanTrue
         }
+        #endif
         expectedListPublicPrivateDeleteAttr = [self.baseQuery(with: privateKeyInternalTag) as CFDictionary]
     }
 
@@ -106,9 +108,11 @@ class CryptoManagerTests: XCTestCase {
                                                                                     [],
                                                                                     &accessControlError) as Any
             #endif
-            if #available(macOS 10.15, iOS 13.0, *) {
+            #if os(macOS)
+            if #available(macOS 10.15, *) {
                 privateKeyAttr[kSecUseDataProtectionKeychain] = true
             }
+            #endif
 
             var keyPairAttr = self.baseQuery(with: privateKeyInternalTag)
             keyPairAttr[kSecPrivateKeyAttrs] = privateKeyAttr as Any
@@ -137,9 +141,11 @@ class CryptoManagerTests: XCTestCase {
                                                                                     [.privateKeyUsage],
                                                                                     &accessControlError) as Any
             #endif
-            if #available(macOS 10.15, iOS 13.0, *) {
+            #if os(macOS)
+            if #available(macOS 10.15, *) {
                 privateKeyAttr[kSecUseDataProtectionKeychain] = true
             }
+            #endif
 
             var keyPairAttr = self.baseQuery(with: privateKeyInternalTag)
             keyPairAttr[kSecPrivateKeyAttrs] = privateKeyAttr as Any
@@ -169,9 +175,11 @@ class CryptoManagerTests: XCTestCase {
                                                                                     [.biometryCurrentSet],
                                                                                     &accessControlError) as Any
             #endif
-            if #available(macOS 10.15, iOS 13.0, *) {
+            #if os(macOS)
+            if #available(macOS 10.15, *) {
                 privateKeyAttr[kSecUseDataProtectionKeychain] = true
             }
+            #endif
 
             var keyPairAttr = self.baseQuery(with: privateKeyInternalTag)
             keyPairAttr[kSecPrivateKeyAttrs] = privateKeyAttr as Any
@@ -200,9 +208,11 @@ class CryptoManagerTests: XCTestCase {
                                                                                     [.privateKeyUsage, .biometryCurrentSet],
                                                                                     &accessControlError) as Any
             #endif
+            #if os(macOS)
             if #available(macOS 10.15, iOS 13.0, *) {
                 privateKeyAttr[kSecUseDataProtectionKeychain] = true
             }
+            #endif
 
             var keyPairAttr = self.baseQuery(with: privateKeyInternalTag)
             keyPairAttr[kSecPrivateKeyAttrs] = privateKeyAttr as Any
@@ -261,9 +271,11 @@ class CryptoManagerTests: XCTestCase {
 
     func baseQuery(with tag: String) -> [NSObject: Any] {
         var query: [NSObject: Any] = [kSecClass: kSecClassKey, kSecAttrApplicationTag: tag]
+        #if os(macOS)
         if #available(macOS 10.15, iOS 13.0, *) {
             query[kSecUseDataProtectionKeychain] = kCFBooleanTrue
         }
+        #endif
         return query
     }
 


### PR DESCRIPTION
Make kSecUseDataProtectionKeychain to be used for MacOS only