### PR TITLE
Sample App - Avoid showing consent screen twice for same pending/push challenge

### DIFF
--- a/Examples/PushSampleApp/SampleApp/RootCoordinator.swift
+++ b/Examples/PushSampleApp/SampleApp/RootCoordinator.swift
@@ -95,12 +95,12 @@ class RootCoordinator {
             nav.dismiss(animated: true)
         }
         userConsentVC.viewModel = viewModel
-        if nav.presentedViewController != nil {
+        if nav.presentedViewController == nil {
+            nav.present(userConsentVC, animated: true)
+        } else {
             nav.dismiss(animated: true) {
                 nav.present(userConsentVC, animated: true)
             }
-        } else {
-            nav.present(userConsentVC, animated: true)
         }
     }
 

--- a/Examples/PushSampleApp/SampleApp/UserConsent/UserConsentViewModel.swift
+++ b/Examples/PushSampleApp/SampleApp/UserConsent/UserConsentViewModel.swift
@@ -28,7 +28,7 @@ protocol UserConsentViewModelProtocol {
 
 struct UserConsentViewModel: UserConsentViewModelProtocol {
 
-    private let remediationStep: RemediationStepUserConsent
+    let remediationStep: RemediationStepUserConsent
 
     var onRemediationComplete: () -> Void = {}
 


### PR DESCRIPTION
Checking by transactionID before presenting the user consent screen