### PR TITLE
Add requestReferrer to supported claims

### DIFF
--- a/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
@@ -36,6 +36,7 @@ enum OktaJWTClaims {
     case userVerification
     case userMediation
     case authenticatorEnrollmentId
+    case requestReferrer
 }
 
 class OktaBindJWT {
@@ -143,6 +144,10 @@ class OktaBindJWT {
 
     lazy var authenticatorEnrollmentId: String? = {
         return self.jwt.payload[OktaJWTClaims.authenticatorEnrollmentId.rawValue] as? String
+    }()
+
+    lazy var requestReferrer: String? = {
+        return self.jwt.payload[OktaJWTClaims.requestReferrer.rawValue] as? String
     }()
 
     init(string input: String,
@@ -337,6 +342,8 @@ extension OktaJWTClaims {
             return "signalProviders"
         case .authenticatorEnrollmentId:
             return "authenticatorEnrollmentId"
+        case .requestReferrer:
+            return "requestReferrer"
         }
     }
 }


### PR DESCRIPTION
### Problem Analysis (Technical)
When approving an authentication request, the user doesn't necessarily know the source by referring to only the `iss` claim, as vanity urls aren't represented by that claim.

### Solution (Technical)
Expose the secondary claim `requestReferrer` that includes the vanity url, if necessary, to provide fuller context to the user.

### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
