### PR TITLE
Add enrollmentsCount method from sqlite

### DIFF
--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
@@ -200,6 +200,18 @@ class OktaSharedSQLite: OktaSharedSQLiteProtocol {
         return enrollments
     }
 
+    var enrollmentsCount: Int? {
+        var count: Int?
+        do {
+            try pool?.read({ db in
+                count = try Int.fetchOne(db, sql: "SELECT COUNT(*) from Enrollment")
+            })
+        } catch {
+            logger.error(eventName: "Error while getting authenticators count from SQLite", message: "Error: \(error)")
+        }
+        return count
+    }
+
     func enrollment(from row: Row, db: Database) -> AuthenticatorEnrollmentProtocol? {
         guard let enrollmentId = row.enrollmentId,
               let orgId = row.orgId,

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
@@ -141,6 +141,24 @@ class OktaSharedSQLiteTests: XCTestCase {
     func testStoreRetrieveEnrollmentWithError() throws {
         try storeRetrieveEnrollmentWithError(fullDatabaseEncryption: false, prefersSecureEnclaveUsage: false)
     }
+    
+    func testEnrollmentsCount_MultipleItems_ReturnsCount() throws {
+        let sqlite = try createSqlite(fullDatabaseEncryption: false, prefersSecureEnclaveUsage: false)
+        let createdDate = "2020-09-08T19:30:30.166Z"
+        let enrollmentA = entitiesGenerator.createAuthenticator(createdDate: createdDate)
+        try? sqlite.storeEnrollment(enrollmentA)
+        let enrollmentB = entitiesGenerator.createAuthenticator(createdDate: createdDate)
+        try? sqlite.storeEnrollment(enrollmentB)
+        let enrollmentC = entitiesGenerator.createAuthenticator(createdDate: createdDate)
+        try? sqlite.storeEnrollment(enrollmentC)
+        
+        XCTAssertEqual(sqlite.enrollmentsCount, 3)
+    }
+    
+    func testEnrollmentsCount_emptyItems_Returns0() throws {
+        let sqlite = try createSqlite(fullDatabaseEncryption: false, prefersSecureEnclaveUsage: false)        
+        XCTAssertEqual(sqlite.enrollmentsCount, 0)
+    }
 
     func storeRetrieveEnrollmentWithError(fullDatabaseEncryption: Bool, prefersSecureEnclaveUsage: Bool) throws {
         let sqlite = try createSqlite(fullDatabaseEncryption: fullDatabaseEncryption, prefersSecureEnclaveUsage: prefersSecureEnclaveUsage)


### PR DESCRIPTION
### Problem Analysis (Technical)
For migration and for the future, adding a count method to retrieve count of enrollments without pulling all into memory.

### Solution (Technical)


### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
