### PR TITLE
OKTA-540404 - Push SDK: Refactor enrollment flow in order to support different server APIs(legacy vs MyAccount)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,13 +6,13 @@ PODS:
     - GRDB.swift (~> 5)
     - OktaJWT (~> 2.3)
     - OktaLogger/FileLogger (~> 1)
-  - GRDB.swift (5.26.0):
-    - GRDB.swift/standard (= 5.26.0)
-  - GRDB.swift/standard (5.26.0)
+  - GRDB.swift (5.26.1):
+    - GRDB.swift/standard (= 5.26.1)
+  - GRDB.swift/standard (5.26.1)
   - OktaJWT (2.3.5)
-  - OktaLogger/Core (1.3.8):
+  - OktaLogger/Core (1.3.12):
     - SwiftLint
-  - OktaLogger/FileLogger (1.3.8):
+  - OktaLogger/FileLogger (1.3.12):
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
@@ -40,11 +40,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
   DeviceAuthenticator: c9639a7ee99d41be8f41cb8480b5a57855615bfa
-  GRDB.swift: 1395cb3556df6b16ed69dfc74c3886abc75d2825
+  GRDB.swift: e98cd55ec99dea5da99355d588149063e4cfa0eb
   OktaJWT: d9934b947fd0742713557b9ab9e1a313d40751cc
-  OktaLogger: f92c0fd63642204558cbef3755050cf80b107820
+  OktaLogger: 7788647b3748015cc367e3b767d40b0c9e3a391a
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
 
 PODFILE CHECKSUM: 35f87805fa2e9982731e944dbb61a22838164626
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.3

--- a/Sources/DeviceAuthenticator/DomainObjects/EnrollAuthenticatorRequestModel.swift
+++ b/Sources/DeviceAuthenticator/DomainObjects/EnrollAuthenticatorRequestModel.swift
@@ -12,8 +12,41 @@
 
 import Foundation
 
-typealias UserVerificationEncodableValue = EnrollAuthenticatorRequestModel.AuthenticatorMethods.Keys.UserVerificationKey
-typealias APSEnvironmentEncodableValue = EnrollAuthenticatorRequestModel.AuthenticatorMethods.APSEnvironment
+typealias UserVerificationEncodableValue = SigningKeysModel.UserVerificationKey
+typealias APSEnvironmentEncodableValue = APSEnvironment
+
+enum APSEnvironment: String, Encodable {
+    case development
+    case production
+}
+
+struct SigningKeysModel: Encodable {
+    let proofOfPossession: [String: _OktaCodableArbitaryType]?
+    let userVerification: UserVerificationKey?
+
+    enum UserVerificationKey: Encodable {
+        case null
+        case keyValue([String: _OktaCodableArbitaryType])
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .null:
+                try container.encodeNil()
+            case .keyValue(let kayValue):
+                try container.encode(kayValue)
+            }
+        }
+
+        func value() -> [String: _OktaCodableArbitaryType]? {
+            switch self {
+            case .null:
+                return nil
+            case .keyValue(let kayValue):
+                return kayValue
+            }
+        }
+    }
+}
 
 struct EnrollAuthenticatorRequestModel: Encodable {
 
@@ -29,39 +62,6 @@ struct EnrollAuthenticatorRequestModel: Encodable {
         let apsEnvironment: APSEnvironment?
         let supportUserVerification: Bool? // For TOTP factor
         let isFipsCompliant: Bool? // For TOTP
-        let keys: Keys?
-
-        enum APSEnvironment: String, Encodable {
-            case development
-            case production
-        }
-
-        struct Keys: Encodable {
-            let proofOfPossession: [String: _OktaCodableArbitaryType]?
-            let userVerification: UserVerificationKey?
-
-            enum UserVerificationKey: Encodable {
-                case null
-                case keyValue([String: _OktaCodableArbitaryType])
-                func encode(to encoder: Encoder) throws {
-                    var container = encoder.singleValueContainer()
-                    switch self {
-                    case .null:
-                        try container.encodeNil()
-                    case .keyValue(let kayValue):
-                        try container.encode(kayValue)
-                    }
-                }
-
-                func value() -> [String: _OktaCodableArbitaryType]? {
-                    switch self {
-                    case .null:
-                        return nil
-                    case .keyValue(let kayValue):
-                        return kayValue
-                    }
-                }
-            }
-        }
+        let keys: SigningKeysModel?
     }
 }

--- a/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
+++ b/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
@@ -23,16 +23,11 @@ class LegacyServerAPI: ServerAPIProtocol {
         self.logger = logger
     }
 
-    /// - Description: Downloads Authenticator MetaData
-    /// - Parameters:
-    ///   - orgHost:         Organization host url
-    ///   - token:           Authentication token(access token, one time token or signed jwt)
-    ///   - completion:      Handler to execute after the async call completes
     func downloadAuthenticatorMetadata(orgHost: URL,
                                        authenticatorKey: String,
                                        oidcClientId: String?,
                                        token: OktaRestAPIToken,
-                                       completion: @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void
+                                       completion: @escaping (_ result: Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void
     ) {
         var urlComponents = URLComponents(url: orgHost.appendingPathComponent("/api/v1/authenticators"), resolvingAgainstBaseURL: true)
         urlComponents?.queryItems = [URLQueryItem(name: "key", value: authenticatorKey),
@@ -42,7 +37,7 @@ class LegacyServerAPI: ServerAPIProtocol {
         }
         guard let metaDataURL = urlComponents?.url else {
             logger.error(eventName: "Invalid URL provided", message: nil)
-            completion(nil, DeviceAuthenticatorError.internalError("Invalid URL"))
+            completion(.failure(DeviceAuthenticatorError.internalError("Invalid URL")))
             return
         }
 
@@ -51,15 +46,186 @@ class LegacyServerAPI: ServerAPIProtocol {
         self.client
             .request(metaDataURL)
             .addHeader(name: httpAuthorizationHeaderName, value: authorizationHeaderValue(forAuthType: token.type, withToken: token.token))
+            .response { result in
+                do {
+                    try self.validateResult(result, for: metaDataURL)
+                } catch let oktaError as DeviceAuthenticatorError {
+                    completion(.failure(oktaError))
+                    return
+                } catch {
+                    let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+                    self.logger.error(eventName: "API error", message: "error: \(resultError) for request at URL: \(metaDataURL)")
+                    completion(.failure(resultError))
+                    return
+                }
+
+                guard let metaDataJson = result.data else {
+                    let resultError = DeviceAuthenticatorError.internalError("Server replied with an empty data")
+                    self.logger.error(eventName: "Policy request", message: "Download metadata error - \(resultError)")
+                    completion(Result.failure(resultError))
+                    return
+                }
+
+                let metaData: AuthenticatorMetaDataModel
+                do {
+                    let metaDataArray = try JSONDecoder().decode([AuthenticatorMetaDataModel].self, from: metaDataJson).filter({
+                        $0.status == .active
+                    })
+                    guard !metaDataArray.isEmpty else {
+                        completion(Result.failure(DeviceAuthenticatorError.internalError("Server replied with empty active authenticators array")))
+                        return
+                    }
+
+                    metaData = metaDataArray[0]
+                    completion(Result.success(metaData))
+                } catch {
+                    let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+                    self.logger.error(eventName: "Policy request", message: "Download metadata error - \(resultError)")
+                    completion(Result.failure(resultError))
+                }
+            }
+    }
+
+    func enrollAuthenticatorRequest(orgHost: URL,
+                                    metadata: AuthenticatorMetaDataModel,
+                                    deviceModel: DeviceSignalsModel,
+                                    appSignals: [String: _OktaCodableArbitaryType]?,
+                                    enrollingFactors: [EnrollingFactor],
+                                    token: OktaRestAPIToken,
+                                    completion: @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) {
+        let enrollRequestJson: Data
+        do {
+            logger.info(eventName: "Enroll request", message: "Building request json object")
+            enrollRequestJson = try buildEnrollmentRequestData(metadata: metadata,
+                                                               deviceModel: deviceModel,
+                                                               appSignals: appSignals,
+                                                               enrollingFactors: enrollingFactors)
+        } catch {
+            let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+            logger.error(eventName: "Enroll request", message: "Error: \(resultError)")
+            completion(nil, resultError)
+            return
+        }
+
+        let finalURL: URL
+        if let enrollLink = metadata._links.enroll?.href,
+            let enrollURL = URL(string: enrollLink) {
+            finalURL = enrollURL
+        } else {
+            finalURL = orgHost.appendingPathComponent("/idp/authenticators")
+        }
+        logger.info(eventName: "Enrolling Authenticator", message: "URL: \(finalURL)")
+        self.client
+            .request(finalURL, method: .post, httpBody: enrollRequestJson, headers: [HTTPHeaderConstants.contentTypeHeader: "application/json"])
+            .addHeader(name: HTTPHeaderConstants.authorizationHeader, value: authorizationHeaderValue(forAuthType: token.type, withToken: token.token))
             .response { (result) in
                 if let error = result.error {
                     let resultError = DeviceAuthenticatorError.networkError(error)
-                    self.logger.error(eventName: "API error", message: "error: \(resultError) for request at URL: \(metaDataURL)")
+                    self.logger.error(eventName: "API error", message: "error: \(resultError) for request at URL: \(finalURL)")
                     completion(result, resultError)
                     return
                 }
 
-                self.validateResult(result, for: metaDataURL, andCall: completion)
+                guard result.data != nil else {
+                    let resultError = DeviceAuthenticatorError.internalError("Server replied with an empty data")
+                    self.logger.error(eventName: "Policy request", message: "Download metadata error - \(resultError)")
+                    completion(nil, resultError)
+                    return
+                }
+
+                do {
+                    try self.validateResult(result, for: finalURL)
+                    completion(result, nil)
+                } catch let oktaError as DeviceAuthenticatorError {
+                    completion(nil, oktaError)
+                    return
+                } catch {
+                    let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+                    self.logger.error(eventName: "API error", message: "error: \(resultError) for request at URL: \(finalURL)")
+                    completion(nil, resultError)
+                    return
+                }
             }
+    }
+
+    func updateAuthenticatorRequest(orgHost: URL,
+                                    enrollmentId: String,
+                                    metadata: AuthenticatorMetaDataModel,
+                                    deviceModel: DeviceSignalsModel,
+                                    appSignals: [String: _OktaCodableArbitaryType]?,
+                                    enrollingFactors: [EnrollingFactor],
+                                    token: OktaRestAPIToken,
+                                    completion: @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) {
+        let enrollRequestJson: Data
+        do {
+            logger.info(eventName: "Update request", message: "Building enrollment request")
+            enrollRequestJson = try buildEnrollmentRequestData(metadata: metadata,
+                                                               deviceModel: deviceModel,
+                                                               appSignals: appSignals,
+                                                               enrollingFactors: enrollingFactors)
+        } catch {
+            let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+            logger.error(eventName: "Update request", message: "Error: \(resultError)")
+            completion(nil, resultError)
+            return
+        }
+
+        let finalURL: URL = orgHost.appendingPathComponent("/idp/authenticators/" + enrollmentId)
+        logger.info(eventName: "Updating Authenticator", message: "URL: \(finalURL)")
+        if case .none = token {
+            completion(nil, DeviceAuthenticatorError.internalError("No token provided for update enrollment request"))
+            return
+        }
+
+        self.client
+            .request(finalURL, method: .put, httpBody: enrollRequestJson, headers: [HTTPHeaderConstants.contentTypeHeader: "application/json"])
+            .addHeader(name: HTTPHeaderConstants.authorizationHeader, value: authorizationHeaderValue(forAuthType: token.type, withToken: token.token))
+            .response { (result) in
+                if let error = result.error {
+                    let resultError = DeviceAuthenticatorError.networkError(error)
+                    self.logger.error(eventName: "API error", message: "\(resultError), for request at URL: \(finalURL)")
+                    completion(result, resultError)
+                    return
+                }
+
+                do {
+                    try self.validateResult(result, for: finalURL)
+                    completion(result, nil)
+                } catch let oktaError as DeviceAuthenticatorError {
+                    completion(nil, oktaError)
+                    return
+                } catch {
+                    let resultError = DeviceAuthenticatorError.internalError(error.localizedDescription)
+                    self.logger.error(eventName: "API error", message: "error: \(resultError) for request at URL: \(finalURL)")
+                    completion(nil, resultError)
+                    return
+                }
+            }
+    }
+
+    func buildEnrollmentRequestData(metadata: AuthenticatorMetaDataModel,
+                                    deviceModel: DeviceSignalsModel,
+                                    appSignals: [String: _OktaCodableArbitaryType]?,
+                                    enrollingFactors: [EnrollingFactor]) throws -> Data {
+        let methods = enrollingFactors.compactMap { factor in
+            if factor.keys != nil {
+                let methodModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods(type: factor.methodType,
+                                                                                       pushToken: factor.methodType == .push ? factor.pushToken : nil,
+                                                                                       apsEnvironment: factor.methodType == .push ? factor.apsEnvironment : nil,
+                                                                                       supportUserVerification: factor.supportUserVerification,
+                                                                                       isFipsCompliant: factor.isFipsCompliant,
+                                                                                       keys: factor.keys)
+
+                return methodModel
+            } else {
+                return nil
+            }
+        }
+        let enrollRequestModel = EnrollAuthenticatorRequestModel(authenticatorId: metadata.id,
+                                                                 key: metadata.key,
+                                                                 device: deviceModel,
+                                                                 appSignals: appSignals,
+                                                                 methods: methods)
+        return try JSONEncoder().encode(enrollRequestModel)
     }
 }

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll+Push.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll+Push.swift
@@ -19,15 +19,10 @@ extension OktaTransactionEnroll {
         let pushFactor = enrollmentToUpdate?.enrolledFactors.first(where: { $0 is OktaFactorPush }) as? OktaFactorPush
         let proofOfPossessionKeyTag = pushFactor?.proofOfPossessionKeyTag
         let userVerificationKeyTag = pushFactor?.userVerificationKeyTag
-        let returnedTuple = try createAuthenticatorMethodModel(with: proofOfPossessionKeyTag,
-                                                               uvKeyTag: userVerificationKeyTag,
-                                                               methodType: .push,
-                                                               pushToken: enrollmentContext.pushToken.rawValue)
-
-        let enrollingFactor = EnrollingFactor(proofOfPossessionKeyTag: returnedTuple.proofOfPossessionKeyTag,
-                                              userVerificationKeyTag: returnedTuple.userVerificationKeyTag,
-                                              methodType: .push,
-                                              requestModel: returnedTuple.methodModel)
+        let enrollingFactor = try createEnrollingFactorModel(with: proofOfPossessionKeyTag,
+                                                                 uvKeyTag: userVerificationKeyTag,
+                                                                 methodType: .push,
+                                                                 pushToken: enrollmentContext.pushToken.rawValue)
         return enrollingFactor
     }
 }

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -99,14 +99,13 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         enrollment.enrolledFactors.append(pushFactor)
         var updateAuthenticatorRequestHookCalled = false
         let pushTokenToCompare = "push_token".data(using: .utf8)!
-        restAPIMock.updateAuthenticatorRequestHook = { url, data, token, completion in
-            let dict = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
-            let pushMethod = (dict["methods"] as! Array<[String: Any]>).first
-            let pushToken = pushMethod!["pushToken"] as! String
+        restAPIMock.updateAuthenticatorRequestHook = { url, enrollmentId, metadata, deviceSignalsModel, allSignals, factors, _, completion in
+            let pushMethod = factors.first(where: { $0.methodType == .push })
+            let pushToken = pushMethod?.pushToken
             XCTAssertEqual(pushToken, pushTokenToCompare.hexString())
             let result = HTTPURLResult(request: URLRequest(url: URL(string: "com.okta.example")!),
-                                    response: HTTPURLResponse(url: self.mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!,
-                                    data: GoldenData.authenticatorData())
+                                       response: HTTPURLResponse(url: self.mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                                       data: GoldenData.authenticatorData())
             updateAuthenticatorRequestHookCalled = true
             completion(result, nil)
         }
@@ -247,7 +246,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try? mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var updateAuthenticatorRequestHookCalled = false
-        restAPIMock.updateAuthenticatorRequestHook = { url, data, token, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { url, data, token, _, _, _, _, completion in
             let result = HTTPURLResult(request: URLRequest(url: URL(string: "com.okta.example")!),
                                     response: HTTPURLResponse(url: self.mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!,
                                     data: GoldenData.authenticatorData())

--- a/Tests/DeviceAuthenticatorUnitTests/EnrollAuthenticatorRequestModelTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/EnrollAuthenticatorRequestModelTests.swift
@@ -47,9 +47,8 @@ class EnrollAuthenticatorRequestModelTests: XCTestCase {
 
     func testKeysEncoding() {
         // test user verification `null` value
-        var keysModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods.Keys(proofOfPossession: ["key": .string("value")],
-                                                                             userVerification:
-                                                                                EnrollAuthenticatorRequestModel.AuthenticatorMethods.Keys.UserVerificationKey.null)
+        var keysModel = SigningKeysModel(proofOfPossession: ["key": .string("value")],
+                                         userVerification: SigningKeysModel.UserVerificationKey.null)
         let encoder = JSONEncoder()
         var encodedData = try? encoder.encode(keysModel)
         XCTAssertNotNil(encodedData)
@@ -57,9 +56,8 @@ class EnrollAuthenticatorRequestModelTests: XCTestCase {
         XCTAssertTrue(encodedString!.contains("\"userVerification\":null"))
 
         // test user verification with jwt
-        keysModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods.Keys(proofOfPossession: ["key": .string("value")],
-                                                                             userVerification:
-                                                                                EnrollAuthenticatorRequestModel.AuthenticatorMethods.Keys.UserVerificationKey.keyValue(["uvKey": .string("uvValue")]))
+        keysModel = SigningKeysModel(proofOfPossession: ["key": .string("value")],
+                                     userVerification: SigningKeysModel.UserVerificationKey.keyValue(["uvKey": .string("uvValue")]))
         encodedData = try? encoder.encode(keysModel)
         XCTAssertNotNil(encodedData)
         encodedString = String(data: encodedData!, encoding: .utf8)

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -16,10 +16,10 @@ import Foundation
 
 class RestAPIMock: ServerAPIProtocol {
 
-    typealias enrollAuthenticatorRequestType = (URL, Data, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
+    typealias enrollAuthenticatorRequestType = (URL, AuthenticatorMetaDataModel, DeviceSignalsModel, [String : _OktaCodableArbitaryType]?, [EnrollingFactor], OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias downloadOrgIdType = (URL, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
-    typealias updateAuthenticatorRequestType = (URL, Data, OktaRestAPIToken, @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
-    typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
+    typealias updateAuthenticatorRequestType = (URL, String, AuthenticatorMetaDataModel, DeviceSignalsModel, [String : _OktaCodableArbitaryType]?, [EnrollingFactor], OktaRestAPIToken, @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
+    typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void) -> Void
     typealias deleteAuthenticatorRequestType = (URL, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias pendingChallengeRequestType = (URL, AuthToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
 
@@ -63,7 +63,7 @@ class RestAPIMock: ServerAPIProtocol {
                                               authenticatorKey: String,
                                               oidcClientId: String?,
                                               token: OktaRestAPIToken,
-                                              completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
+                                              completion: @escaping (Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void) {
         if let downloadAuthenticatorMetadataHook = downloadAuthenticatorMetadataHook {
             downloadAuthenticatorMetadataHook(orgHost, authenticatorKey, token, completion)
         } else {
@@ -75,7 +75,11 @@ class RestAPIMock: ServerAPIProtocol {
         }
     }
 
-    public func enrollAuthenticatorRequest(enrollURL: URL, data: Data,
+    public func enrollAuthenticatorRequest(orgHost: URL,
+                                           metadata: AuthenticatorMetaDataModel,
+                                           deviceModel: DeviceSignalsModel,
+                                           appSignals: [String : _OktaCodableArbitaryType]?,
+                                           enrollingFactors: [EnrollingFactor],
                                            token: OktaRestAPIToken,
                                            completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
         if let oktaError = error {
@@ -84,25 +88,42 @@ class RestAPIMock: ServerAPIProtocol {
         }
 
         if let enrollAuthenticatorRequestHook = enrollAuthenticatorRequestHook {
-            enrollAuthenticatorRequestHook(enrollURL, data, token, completion)
+            enrollAuthenticatorRequestHook(orgHost, metadata, deviceModel, appSignals, enrollingFactors, token, completion)
         } else {
-            restAPI.enrollAuthenticatorRequest(enrollURL: enrollURL,
-                                               data: data,
+            restAPI.enrollAuthenticatorRequest(orgHost: orgHost,
+                                               metadata: metadata,
+                                               deviceModel: deviceModel,
+                                               appSignals: appSignals,
+                                               enrollingFactors: enrollingFactors,
                                                token: token,
                                                completion: completion)
         }
     }
 
-    public func updateAuthenticatorRequest(url: URL, data: Data, token: OktaRestAPIToken, completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
+    public func updateAuthenticatorRequest(orgHost: URL,
+                                           enrollmentId: String,
+                                           metadata: AuthenticatorMetaDataModel,
+                                           deviceModel: DeviceSignalsModel,
+                                           appSignals: [String: _OktaCodableArbitaryType]?,
+                                           enrollingFactors: [EnrollingFactor],
+                                           token: OktaRestAPIToken,
+                                           completion: @escaping (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) {
         if let oktaError = error {
             completion(nil, oktaError)
             return
         }
 
         if let updateAuthenticatorRequestHook = updateAuthenticatorRequestHook {
-            updateAuthenticatorRequestHook(url, data, token, completion)
+            updateAuthenticatorRequestHook(orgHost, enrollmentId, metadata, deviceModel, appSignals, enrollingFactors, token, completion)
         } else {
-            restAPI.updateAuthenticatorRequest(url: url, data: data, token: token, completion: completion)
+            restAPI.updateAuthenticatorRequest(orgHost: orgHost,
+                                               enrollmentId: enrollmentId,
+                                               metadata: metadata,
+                                               deviceModel: deviceModel,
+                                               appSignals: appSignals,
+                                               enrollingFactors: enrollingFactors,
+                                               token: token,
+                                               completion: completion)
         }
     }
 

--- a/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticatorsManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticatorsManagerTests.swift
@@ -204,7 +204,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         let deleteKeyHookCalled = expectation(description: "Delete hook expected!")
         // Delete push keys(pop, uv), delete clientInstanceKey = 5 calls
         deleteKeyHookCalled.expectedFulfillmentCount = 3
-        restAPI.enrollAuthenticatorRequestHook = { _, _, _, completion in
+        restAPI.enrollAuthenticatorRequestHook = { _, _, _, _, _, _, completion in
             self.secHelperMock.deleteKeyHook = { query in
                 deleteKeyHookCalled.fulfill()
                 return noErr


### PR DESCRIPTION
### Problem Analysis (Technical)
We need to move out API models building/parsing logic from enrollment transaction. In that case enrollment transaction impl will be server API agnostic

Note: unit test coverage for LegacyServerAPI class will be added in next PR

### Solution (Technical)


### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
