### PR TITLE
Adds Equatable to ServerErrorCode

### DIFF
--- a/Sources/DeviceAuthenticator/Networking/ServerErrorCodes.swift
+++ b/Sources/DeviceAuthenticator/Networking/ServerErrorCodes.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Errors that the Okta server returns
-public enum ServerErrorCode: Codable {
+public enum ServerErrorCode: Codable, Equatable {
     /// Operation blocked because the verification attempt might be trying to steal your information.
     case phishingAttemptDetected
     /// Operation failed because enrollment no longer exists on server side


### PR DESCRIPTION
### Problem Analysis (Technical)

Attempting to compare ServerErrorCodes results in `Operator function '==' requires that 'ServerErrorCode' conform to 'Equatable'`

### Solution (Technical)

Add Equatable protocol conformance to ServerErrorCode

`public enum ServerErrorCode: Codable, Equatable `


### Affected Components

ServerErrorCode

### Steps to reproduce:

Actual result: N/A

Expected result: N/A

### Tests

N/A