### PR TITLE
OKTA-543909 - Remove keys check when adding EnrollingFactors preventing TOTP methods to be added

### DIFF
--- a/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
+++ b/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
@@ -211,24 +211,20 @@ class LegacyServerAPI: ServerAPIProtocol {
                                     appSignals: [String: _OktaCodableArbitaryType]?,
                                     enrollingFactors: [EnrollingFactor]) throws -> Data {
         let methods: [EnrollAuthenticatorRequestModel.AuthenticatorMethods] = enrollingFactors.compactMap { factor in
-            if factor.keys != nil {
-                var transactionTypes: [MethodSettingsModel.TransactionType] = [.LOGIN]
-                if factor.transactionTypes.supportsCIBA {
-                    transactionTypes.append(.CIBA)
-                }
-                let capabilities = Capabilities(transactionTypes: transactionTypes)
-                let methodModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods(type: factor.methodType,
-                                                                                       pushToken: factor.methodType == .push ? factor.pushToken : nil,
-                                                                                       apsEnvironment: factor.methodType == .push ? factor.apsEnvironment : nil,
-                                                                                       supportUserVerification: factor.supportUserVerification,
-                                                                                       isFipsCompliant: factor.isFipsCompliant,
-                                                                                       keys: factor.keys,
-                                                                                       capabilities: capabilities)
-
-                return methodModel
-            } else {
-                return nil
+            var transactionTypes: [MethodSettingsModel.TransactionType] = [.LOGIN]
+            if factor.transactionTypes.supportsCIBA {
+                transactionTypes.append(.CIBA)
             }
+            let capabilities = Capabilities(transactionTypes: transactionTypes)
+            let methodModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods(type: factor.methodType,
+                                                                                   pushToken: factor.methodType == .push ? factor.pushToken : nil,
+                                                                                   apsEnvironment: factor.methodType == .push ? factor.apsEnvironment : nil,
+                                                                                   supportUserVerification: factor.supportUserVerification,
+                                                                                   isFipsCompliant: factor.isFipsCompliant,
+                                                                                   keys: factor.keys,
+                                                                                   capabilities: capabilities)
+
+            return methodModel
         }
         let enrollRequestModel = EnrollAuthenticatorRequestModel(authenticatorId: metadata.id,
                                                                  key: metadata.key,

--- a/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
+++ b/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
@@ -211,11 +211,14 @@ class LegacyServerAPI: ServerAPIProtocol {
                                     appSignals: [String: _OktaCodableArbitaryType]?,
                                     enrollingFactors: [EnrollingFactor]) throws -> Data {
         let methods: [EnrollAuthenticatorRequestModel.AuthenticatorMethods] = enrollingFactors.compactMap { factor in
-            var transactionTypes: [MethodSettingsModel.TransactionType] = [.LOGIN]
-            if factor.transactionTypes.supportsCIBA {
-                transactionTypes.append(.CIBA)
+            var capabilities: Capabilities?
+            if factor.methodType == .push {
+                var transactionTypes: [MethodSettingsModel.TransactionType] = [.LOGIN]
+                if factor.transactionTypes.supportsCIBA {
+                    transactionTypes.append(.CIBA)
+                }
+                capabilities = Capabilities(transactionTypes: transactionTypes)
             }
-            let capabilities = Capabilities(transactionTypes: transactionTypes)
             let methodModel = EnrollAuthenticatorRequestModel.AuthenticatorMethods(type: factor.methodType,
                                                                                    pushToken: factor.methodType == .push ? factor.pushToken : nil,
                                                                                    apsEnvironment: factor.methodType == .push ? factor.apsEnvironment : nil,


### PR DESCRIPTION
### Problem Analysis (Technical)
OV was broken due to recent MyAccount refactor. TOTP method was not being added to the list of Methods due to unnecessarily checking for the factor.keys on the totp enrollment and therefore OV was not showing any enrollment after adding an account.

### Solution (Technical)
Remove extra check for factor.keys since all Methods add this property since it's optional.

### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
