### PR TITLE
OKTA-555685 - FixIt: Add keychain sharing group id into Devices SDK

### DIFF
--- a/Sources/DeviceAuthenticator/ApplicationConfig.swift
+++ b/Sources/DeviceAuthenticator/ApplicationConfig.swift
@@ -39,16 +39,17 @@ public class ApplicationConfig {
     /// - Parameters:
     ///   - applicationName: Host application name, can be application bundle id
     ///   - applicationVersion: Host application version
-    ///   - applicationGroupId: AppGroupId or KeychainSharing entitlement identifier
+    ///   - applicationGroupId: AppGroupId entitlement identifier for sharing files and keychain items between applications and extensions
+    ///   - keychainGroupId: Optional KeychainSharing entitlement identifier for sharing keychain data. If not provided by your application then sdk falls back to applicationGroupId entitlement for keychain operations
     public init(applicationName: String,
                 applicationVersion: String,
-                applicationGroupId: String
-    ) {
-        self.applicationInfo = .init(
+                applicationGroupId: String,
+                keychainGroupId: String? = nil) {
+        self.applicationInfo = OktaApplicationInfo(
             applicationName: applicationName,
             applicationVersion: applicationVersion,
-            applicationGroupId: applicationGroupId
-        )
+            applicationGroupId: applicationGroupId,
+            keychainGroupId: keychainGroupId)
     }
 
     /// Returns a config value for the specified raw key.

--- a/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
@@ -63,7 +63,7 @@ class OktaBindJWT {
     let exp: Int
     let transactionId: String
     let jwtType: String
-    let accessGroupId: String?
+    let applicationGroupId: String?
     let rawChallenge: String
     let validatePayload: Bool
     let allowedClockSkewInSeconds: Int
@@ -151,7 +151,7 @@ class OktaBindJWT {
     }()
 
     init(string input: String,
-         accessGroupId: String? = nil,
+         applicationGroupId: String? = nil,
          validatePayload: Bool = true,
          customizableHeaders: [String: String] = [: ],
          jwtType: String = "okta-devicebind+jwt",
@@ -168,7 +168,7 @@ class OktaBindJWT {
 
         self.rawChallenge = input
         self.jwtType = jwtType
-        self.accessGroupId = accessGroupId
+        self.applicationGroupId = applicationGroupId
         self.logger = logger
         self.orgId = try Self.get(claim: OktaJWTClaims.orgId,
                                   from: jwt,
@@ -266,7 +266,7 @@ class OktaBindJWT {
         var validationOptions = OktaJWTValidator.ValidationOptions.allOptions
         validationOptions.remove(.issuer)
         validator.validationOptionsSet = validationOptions
-        validator.keyStorageManager = try? KeyStore(with: self.accessGroupId, logger: logger)
+        validator.keyStorageManager = try? KeyStore(with: self.applicationGroupId, logger: logger)
         do {
             _ = try validator.isValid(jwtString)
         } catch let error as OktaJWTVerificationError {

--- a/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
@@ -16,14 +16,14 @@ import OktaLogger
 import CryptoKit
 
 class OktaCryptoManager: OktaSharedCryptoProtocol {
-    var accessGroupId: String
+    var keychainGroupId: String
     var secKeyHelper: SecKeyHelper
     var logger: OktaLoggerProtocol
 
-    init(accessGroupId: String,
+    init(keychainGroupId: String,
          secKeyHelper: SecKeyHelper = SecKeyHelper(),
          logger: OktaLoggerProtocol) {
-        self.accessGroupId = accessGroupId
+        self.keychainGroupId = keychainGroupId
         self.secKeyHelper = secKeyHelper
         self.logger = logger
     }
@@ -64,8 +64,8 @@ class OktaCryptoManager: OktaSharedCryptoProtocol {
         }
 
         var keyAttr = baseQuery(with: tag)
-        if !accessGroupId.isEmpty {
-            keyAttr[kSecAttrAccessGroup] = accessGroupId as NSObject
+        if !keychainGroupId.isEmpty {
+            keyAttr[kSecAttrAccessGroup] = keychainGroupId as NSObject
         }
         if useSecureEnclave {
             keyAttr[kSecAttrTokenID] =  kSecAttrTokenIDSecureEnclave as NSObject
@@ -134,8 +134,8 @@ class OktaCryptoManager: OktaSharedCryptoProtocol {
 
     func delete(keyPairWith tag: String) -> Bool {
         var keyQuery = baseQuery(with: tag)
-        if !accessGroupId.isEmpty {
-            keyQuery[kSecAttrAccessGroup] = accessGroupId
+        if !keychainGroupId.isEmpty {
+            keyQuery[kSecAttrAccessGroup] = keychainGroupId
         }
         let statusCode = self.secKeyHelper.deleteKey(keyQuery as CFDictionary)
 
@@ -145,8 +145,8 @@ class OktaCryptoManager: OktaSharedCryptoProtocol {
     func get(keyOf type: KeyType, with tag: String, context: LAContext) -> SecKey? {
         var keyQuery = baseQuery(with: tag)
         keyQuery[kSecReturnRef] = true
-        if !accessGroupId.isEmpty {
-            keyQuery[kSecAttrAccessGroup] = accessGroupId
+        if !keychainGroupId.isEmpty {
+            keyQuery[kSecAttrAccessGroup] = keychainGroupId
         }
         #if !targetEnvironment(simulator)
         keyQuery[kSecUseAuthenticationContext] = context

--- a/Sources/DeviceAuthenticator/Crypto/OktaCryptoProtocol.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaCryptoProtocol.swift
@@ -32,7 +32,7 @@ enum PrivateKeyState {
 }
 
 protocol OktaSharedCryptoProtocol: OktaCryptoProtocol {
-    var accessGroupId: String { get }
+    var keychainGroupId: String { get }
 }
 
 /// Protocol for managing public and private keys

--- a/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
@@ -151,6 +151,7 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
                                                                     storageManager: storageManager,
                                                                     cryptoManager: cryptoManager,
                                                                     restAPI: restAPIClient,
+                                                                    applicationConfig: applicationConfig,
                                                                     logger: logger)
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: allowedClockSkewInSeconds, completion: completion)
     }

--- a/Sources/DeviceAuthenticator/Enrollment/DeviceAuthenticator.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/DeviceAuthenticator.swift
@@ -75,7 +75,7 @@ class DeviceAuthenticator: DeviceAuthenticatorProtocol {
             logger = Self.createLogger()
         }
         logger.info(eventName: "Initializing DeviceAuthenticator", message: nil)
-        let cryptoManager = OktaCryptoManager(accessGroupId: applicationConfig.applicationInfo.applicationGroupId, logger: logger)
+        let cryptoManager = OktaCryptoManager(keychainGroupId: applicationConfig.applicationInfo.keychainGroupId, logger: logger)
         let httpClientLocal = httpClient ?? HTTPClient(urlSession: nil, logger: logger, userAgent: UserAgent.standardUserAgent())
         let restAPIClient = MyAccountServerAPI(client: httpClientLocal,
                                                crypto: cryptoManager,

--- a/Sources/DeviceAuthenticator/Enrollment/OktaApplicationInfo.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/OktaApplicationInfo.swift
@@ -17,14 +17,15 @@ struct OktaApplicationInfo {
     let applicationName: String
     let applicationVersion: String
     let applicationGroupId: String
+    let keychainGroupId: String
 
-    init(
-        applicationName: String,
-        applicationVersion: String,
-        applicationGroupId: String
-    ) {
+    init(applicationName: String,
+         applicationVersion: String,
+         applicationGroupId: String,
+         keychainGroupId: String? = nil) {
         self.applicationName = applicationName
         self.applicationVersion = applicationVersion
         self.applicationGroupId = applicationGroupId
+        self.keychainGroupId = keychainGroupId ?? applicationGroupId
     }
 }

--- a/Sources/DeviceAuthenticator/Managers/_OktaAuthenticatorsManager.swift
+++ b/Sources/DeviceAuthenticator/Managers/_OktaAuthenticatorsManager.swift
@@ -230,7 +230,7 @@ public class _OktaAuthenticatorsManager {
         let bindJWT = try PushChallenge.parse(info: userInfo,
                                               allowedClockSkewInSeconds: allowedClockSkewInSeconds,
                                               validateJWT: validateJWT,
-                                              accessGroupId: cryptoManager.accessGroupId,
+                                              applicationGroupId: applicationConfig.applicationInfo.applicationGroupId,
                                               logger: logger)
 
         guard let context = bindJWT.jwt.payload["challengeContext"] as? [AnyHashable: Any],

--- a/Sources/DeviceAuthenticator/Storage/OktaSharedKeychainStorage.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaSharedKeychainStorage.swift
@@ -21,14 +21,14 @@ class OktaSharedKeychainStorage {
     }
 
     let underlyingStorageDescription: String = OktaSharedKeychainStorage.Constants.storageDescription
-    var sharedAccessId: String?
+    var keychainGroupId: String?
 
     func save(data: Data, with key: String) throws {
         do {
             try secureStorage.set(data: data,
                                   forKey: key,
                                   behindBiometrics: false,
-                                  accessGroup: sharedAccessId,
+                                  accessGroup: keychainGroupId,
                                   accessibility: OktaEnvironment.Constants.keychainAccessibilityFlag)
         } catch let error as NSError {
             let resultError = convertFromSecureStorageError(error)
@@ -39,7 +39,7 @@ class OktaSharedKeychainStorage {
 
     func data(with key: String) throws -> Data {
         do {
-            return try secureStorage.getData(key: key, accessGroup: sharedAccessId)
+            return try secureStorage.getData(key: key, accessGroup: keychainGroupId)
         } catch let error as NSError {
             let resultError = convertFromSecureStorageError(error)
             logger.error(eventName: "Keychain storage error", message: "Keychain storage can't retrieve data for key: \(key), error: \(resultError)")
@@ -56,7 +56,7 @@ class OktaSharedKeychainStorage {
     func fetchKeys(with prefix: String) throws -> [String] {
         do {
             let keys = try secureStorage
-                .getStoredKeys(accessGroup: sharedAccessId)
+                .getStoredKeys(accessGroup: keychainGroupId)
                 .filter {
                     $0.hasPrefix(prefix)
                 }
@@ -70,7 +70,7 @@ class OktaSharedKeychainStorage {
 
     func delete(with key: String) throws {
         do {
-            try secureStorage.delete(key: key, accessGroup: sharedAccessId)
+            try secureStorage.delete(key: key, accessGroup: keychainGroupId)
         } catch let error as NSError {
             let resultError = convertFromSecureStorageError(error)
             logger.error(eventName: "Keychain storage error", message: "Keychain storage can't delete data for key: \(key), error: \(resultError)")
@@ -81,15 +81,15 @@ class OktaSharedKeychainStorage {
     var logger: OktaLoggerProtocol
     let secureStorage: OktaSecureStorage
 
-    init(with appGroupId: String?,
+    init(with keychainGroupId: String?,
          secureStorage: OktaSecureStorage = OktaSecureStorage(),
          logger: OktaLoggerProtocol) throws {
-        self.sharedAccessId = appGroupId
+        self.keychainGroupId = keychainGroupId
         self.secureStorage = secureStorage
         self.logger = logger
         // Check for invalid app group id error
         do {
-            _ = try secureStorage.getData(key: "dummy_key", biometricPrompt: nil, accessGroup: appGroupId)
+            _ = try secureStorage.getData(key: "dummy_key", biometricPrompt: nil, accessGroup: keychainGroupId)
         } catch {
             let nsError = error as NSError
             if nsError.code == errSecMissingEntitlement {

--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSQLiteEncryptionManager.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSQLiteEncryptionManager.swift
@@ -45,14 +45,14 @@ protocol OktaSQLiteColumnEncryptionManagerProtocol {
 class OktaSQLiteEncryptionManager: OktaSQLiteColumnEncryptionManagerProtocol {
     let cryptoManager: OktaSharedCryptoProtocol
     let keychainStorage: OktaSecureStorage
-    let accessGroupId: String
+    let keychainGroupId: String
     var cryptoKey: SymmetricKey?
 
     init(cryptoManager: OktaSharedCryptoProtocol,
-         accessGroupId: String,
+         keychainGroupId: String,
          keychainStorage: OktaSecureStorage = OktaSecureStorage(applicationPassword: nil)) {
         self.cryptoManager = cryptoManager
-        self.accessGroupId = accessGroupId
+        self.keychainGroupId = keychainGroupId
         self.keychainStorage = keychainStorage
     }
 
@@ -91,7 +91,7 @@ class OktaSQLiteEncryptionManager: OktaSQLiteColumnEncryptionManagerProtocol {
 
         let keyTag = EncryptionTag.columnEncryptionKeyTag
         do {
-            let storedPublicKey = try keychainStorage.getData(key: keyTag.rawValue, accessGroup: accessGroupId)
+            let storedPublicKey = try keychainStorage.getData(key: keyTag.rawValue, accessGroup: keychainGroupId)
             let symmetricKey = SymmetricKey(data: storedPublicKey)
             self.cryptoKey = symmetricKey
 
@@ -106,7 +106,7 @@ class OktaSQLiteEncryptionManager: OktaSQLiteColumnEncryptionManagerProtocol {
                     try keychainStorage.set(data: rawKey,
                                             forKey: keyTag.rawValue,
                                             behindBiometrics: false,
-                                            accessGroup: accessGroupId,
+                                            accessGroup: keychainGroupId,
                                             accessibility: kSecAttrAccessibleWhenUnlocked)
 
                     return cryptoKey

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -186,7 +186,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
 
     func parseJWT(string: String) throws -> OktaBindJWT {
         return try OktaBindJWT(string: string,
-                               accessGroupId: cryptoManager.accessGroupId,
+                               applicationGroupId: applicationConfig.applicationInfo.applicationGroupId,
                                logger: logger)
     }
 

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPullChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPullChallenge.swift
@@ -17,16 +17,19 @@ class OktaTransactionPullChallenge: OktaTransaction {
     let restAPI: ServerAPIProtocol
     let enrollment: AuthenticatorEnrollment
     let authenticationToken: AuthToken
+    let applicationConfig: ApplicationConfig
 
     init(enrollment: AuthenticatorEnrollment,
          authenticationToken: AuthToken,
          storageManager: PersistentStorageProtocol,
          cryptoManager: OktaSharedCryptoProtocol,
          restAPI: ServerAPIProtocol,
+         applicationConfig: ApplicationConfig,
          logger: OktaLoggerProtocol) {
         self.restAPI = restAPI
         self.enrollment = enrollment
         self.authenticationToken = authenticationToken
+        self.applicationConfig = applicationConfig
         super.init(loginHint: nil,
                    storageManager: storageManager,
                    cryptoManager: cryptoManager,
@@ -102,7 +105,7 @@ class OktaTransactionPullChallenge: OktaTransaction {
         return try? PushChallenge.parse(info: info,
                                         allowedClockSkewInSeconds: allowedClockSkewInSeconds,
                                         validateJWT: validateJWT,
-                                        accessGroupId: cryptoManager.accessGroupId,
+                                        applicationGroupId: applicationConfig.applicationInfo.applicationGroupId,
                                         logger: logger)
     }
 }

--- a/Sources/DeviceAuthenticator/Transactions/PushChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/PushChallenge.swift
@@ -134,7 +134,7 @@ class PushChallenge: PushChallengeProtocol, CIBAChallengeProtocol {
     static func parse(info: [String: Any],
                       allowedClockSkewInSeconds: Int,
                       validateJWT: Bool = true,
-                      accessGroupId: String,
+                      applicationGroupId: String,
                       logger: OktaLoggerProtocol) throws -> OktaBindJWT {
         var versionKey = info[InternalConstants.PushJWTConstants.payloadVersionKey] as? String
         versionKey = versionKey ?? info[InternalConstants.PushJWTConstants.oktaPayloadVersionKey] as? String
@@ -152,7 +152,7 @@ class PushChallenge: PushChallengeProtocol, CIBAChallengeProtocol {
         }
 
         return try OktaBindJWT(string: challengeJWT,
-                               accessGroupId: accessGroupId,
+                               applicationGroupId: applicationGroupId,
                                validatePayload: validateJWT,
                                jwtType: InternalConstants.PushJWTConstants.pushJWTType,
                                allowedClockSkewInSeconds: allowedClockSkewInSeconds,

--- a/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentFlowTests.swift
+++ b/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentFlowTests.swift
@@ -45,7 +45,7 @@ class EnrollmentFlowTests: XCTestCase {
                                                                         MyAccountTestData.policyResponse(),
                                                                         MyAccountTestData.enrollmentResponse()])
         let oktaRestAPI = MyAccountServerAPI(client: mockHTTPClient,
-                                             crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                             crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                        logger: OktaLoggerMock()),
                                              logger: OktaLoggerMock())
 
@@ -83,7 +83,7 @@ class EnrollmentFlowTests: XCTestCase {
                                                                         MyAccountTestData.policyResponse(),
                                                                         MyAccountTestData.enrollmentResponse()])
         let oktaRestAPI = MyAccountServerAPI(client: mockHTTPClient,
-                                             crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                             crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                        logger: OktaLoggerMock()),
                                              logger: OktaLoggerMock())
 
@@ -116,7 +116,7 @@ class EnrollmentFlowTests: XCTestCase {
                                                                  MyAccountTestData.emptyPolicyArrayResponse(),
                                                                  MyAccountTestData.enrollmentResponse()])
         let oktaRestAPI = MyAccountServerAPI(client: mockHTTPClient,
-                                             crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                             crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                        logger: OktaLoggerMock()),
                                              logger: OktaLoggerMock())
 

--- a/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentTestHelper.swift
+++ b/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentTestHelper.swift
@@ -48,7 +48,7 @@ class EnrollmentTestHelper {
 
         enrollmentParams.enableUserVerification(enable: userVerification)
         let oktaRestAPI = MyAccountServerAPI(client: mockHTTPClient,
-                                             crypto: OktaCryptoManager(accessGroupId: appConfig.applicationInfo.applicationGroupId,
+                                             crypto: OktaCryptoManager(keychainGroupId: appConfig.applicationInfo.applicationGroupId,
                                                                        logger: OktaLoggerMock()),
                                              logger: OktaLoggerMock())
         do {

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -27,7 +27,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                    applicationGroupId: ExampleAppConstants.appGroupId)
 
     override func setUp() {
-        cryptoManager = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         mockStorageManager = StorageMock()
         enrollment = TestUtils.createAuthenticatorEnrollment(orgHost: mockURL,
                                                              orgId: "orgId",
@@ -91,7 +91,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
 
     #if os(iOS)
     func testUpdatePushTokenSuccess() {
-        cryptoManager.accessGroupId = ""
+        cryptoManager.keychainGroupId = ""
         let pushFactor = OktaFactorPush(factorData: OktaFactorMetadataPush(id: "id",
                                                                            proofOfPossessionKeyTag: "proofOfPossessionKeyTag",
                                                                            transactionTypes: .login),
@@ -134,7 +134,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
     #endif
 
     func testUpdatePushTokenError() {
-        cryptoManager.accessGroupId = ""
+        cryptoManager.keychainGroupId = ""
         let enrollment = TestUtils.createAuthenticatorEnrollment(orgHost: mockURL,
                                                                  orgId: "orgId",
                                                                  enrollmentId: "enrollmentId",
@@ -152,7 +152,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
     }
 
     func testRetrievePushChallenges() {
-        cryptoManager.accessGroupId = ""
+        cryptoManager.keychainGroupId = ""
         let pushFactor = OktaFactorPush(factorData: OktaFactorMetadataPush(id: "id",
                                                                            proofOfPossessionKeyTag: "proofOfPossessionKeyTag",
                                                                            links: OktaFactorMetadataPush.Links(pendingLink: "https://test.okta.com/pending_challenge"), transactionTypes: .login),

--- a/Tests/DeviceAuthenticatorUnitTests/CryptoManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/CryptoManagerTests.swift
@@ -34,7 +34,7 @@ class CryptoManagerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         secKeyHelperMock = SecKeyHelperMock()
-        mut = OktaCryptoManager(accessGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
+        mut = OktaCryptoManager(keychainGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
         var expectedPrivateKeyDeleteAttr = [kSecAttrLabel: privateKeyInternalTag as Any,
                                             kSecAttrKeyClass: kSecAttrKeyClassPrivate,
                                             kSecClass: kSecClassKey]
@@ -46,7 +46,7 @@ class CryptoManagerTests: XCTestCase {
 
 #if os(iOS)
     func testEncryptionManager_BasicOperations() {
-        let encryptionManager = OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        let encryptionManager = OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         do {
             let key = try encryptionManager.generate(keyPairWith: .ES256, with: "tag", useSecureEnclave: false, useBiometrics: false)
             XCTAssertNotNil(key)

--- a/Tests/DeviceAuthenticatorUnitTests/LegacyServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/LegacyServerAPITests.swift
@@ -20,7 +20,7 @@ final class LegacyServerAPITests: XCTestCase {
     let metadata = try! JSONDecoder().decode([AuthenticatorMetaDataModel].self, from: GoldenData.authenticatorMetaData()).first!
 
     override func setUpWithError() throws {
-        crypto = OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        crypto = OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
     }
 
     func testDownloadAuthenticatorMetadata_Success() throws {

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/OktaStorageEntitiesGenerator.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/OktaStorageEntitiesGenerator.swift
@@ -49,7 +49,7 @@ class OktaStorageEntitiesGenerator {
                              createdDate: String? = nil,
                              enrolledFactors: [OktaFactor] = [],
                              methodTypes: [AuthenticatorMethod] = [],
-                             cryptoManager: OktaSharedCryptoProtocol = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock()),
+                             cryptoManager: OktaSharedCryptoProtocol = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock()),
                              storageManager: PersistentStorageProtocol? = nil,
                              transactionTypes: TransactionType? = nil) -> AuthenticatorEnrollment {
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [],

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -40,7 +40,7 @@ class RestAPIMock: ServerAPIProtocol {
         self.client = client
         self.logger = logger
         self.restAPI = defaultAPI ?? LegacyServerAPI(client: client,
-                                                     crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                     crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                logger: logger),
                                                      logger: logger)
     }

--- a/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
@@ -20,7 +20,7 @@ final class MyAccountServerAPITests: XCTestCase {
     let metadata = try! JSONDecoder().decode([AuthenticatorMetaDataModel].self, from: MyAccountTestData.authenticatorMetaData()).first!
     
     override func setUpWithError() throws {
-        crypto = OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        crypto = OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
     }
     
     func testDownloadAuthenticatorMetadata_Success() throws {

--- a/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticationJWTGeneratorTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticationJWTGeneratorTests.swift
@@ -21,7 +21,7 @@ class OktaAuthenticationJWTGeneratorTests: XCTestCase {
         _ = secHelper.generateKeyPair([:] as CFDictionary, &publicKey, &privateKey)
         XCTAssertNotNil(privateKey)
         let loggerMock = OktaLoggerMock()
-        let cryptoManager = CryptoManagerMock(accessGroupId: "", secKeyHelper: secHelper, logger: loggerMock)
+        let cryptoManager = CryptoManagerMock(keychainGroupId: "", secKeyHelper: secHelper, logger: loggerMock)
         let jwtGeneratorMock = OktaJWTGeneratorMock(logger: loggerMock)
         var hookCalled = false
         jwtGeneratorMock.generateHook = { jwtType, kid, jwt, key, algo in

--- a/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticatorsManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaAuthenticatorsManagerTests.swift
@@ -29,7 +29,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         super.setUp()
 
         secHelperMock = SecKeyHelperMock()
-        cryptoManager = OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId, secKeyHelper: secHelperMock, logger: OktaLoggerMock())
+        cryptoManager = OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId, secKeyHelper: secHelperMock, logger: OktaLoggerMock())
 
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!, HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!, HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!], dataArray: [GoldenData.orgData(), GoldenData.authenticatorMetaData(), GoldenData.authenticatorData()])
         restAPI = RestAPIMock(client: mockHTTPClient, logger: OktaLoggerMock())
@@ -238,7 +238,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         // suspended
         var mockHTTPClient = MockAPIResponse.response(for: .deviceSuspended)
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
         var ex = expectation(description: "Completion callback expected!")
@@ -256,7 +256,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         // deleted
         mockHTTPClient = MockAPIResponse.response(for: .userDeleted)
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
         ex = expectation(description: "Completion callback expected!")
@@ -281,7 +281,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
                                                                  cryptoManager: cryptoManager)
         var mockHTTPClient = MockAPIResponse.response(for: .enrollmentDeleted)
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
         var ex = expectation(description: "Completion callback expected!")
@@ -294,7 +294,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         // suspended state
         mockHTTPClient = MockAPIResponse.response(for: .userSuspended)
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
         ex = expectation(description: "Completion callback expected!")
@@ -307,7 +307,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
         // deleted state
         mockHTTPClient = MockAPIResponse.response(for: .userDeleted)
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
         ex = expectation(description: "Completion callback expected!")
@@ -323,7 +323,7 @@ class OktaAuthenticatorsManagerTests: XCTestCase {
             response: HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil),
             data: GoldenData.authenticatorMetaData())
         authenticatorManager.restAPI = LegacyServerAPI(client: mockHTTPClient,
-                                                       crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                                       crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                                  logger: OktaLoggerMock()),
                                                        logger: OktaLoggerMock())
 

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceBindJWTTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceBindJWTTests.swift
@@ -157,7 +157,7 @@ class OktaDeviceBindJWTTests: XCTestCase {
     }
 
     func testDeviceChallengeResponseJWTGeneration() {
-        let cryptoManager = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        let cryptoManager = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         _ = try? cryptoManager.generate(keyPairWith: .ES256, with: "kid", useSecureEnclave: false, useBiometrics: false)
         let key = cryptoManager.get(keyOf: .privateKey, with: "kid")
         let mut = try? OktaBindJWT(string: OktaJWTTestData.validDeviceChallengeRequestJWT(), validatePayload: false, logger: OktaLoggerMock())
@@ -388,7 +388,7 @@ class OktaDeviceBindJWTPartialMock: OktaBindJWT {
         self.ignoreExpValidation = ignoreExpValidation
         self.ignoreIatValidation = ignoreIatValidation
         try super.init(string: input,
-                       accessGroupId: accessGroupId,
+                       applicationGroupId: accessGroupId,
                        validatePayload: validatePayload,
                        customizableHeaders: customizableHeaders,
                        allowedClockSkewInSeconds: allowedClockSkewInSeconds,

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -32,7 +32,7 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         super.setUp()
 
         let secKeyHelperMock = SecKeyHelperMock()
-        cryptoManager = CryptoManagerMock(accessGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
         jwkGenerator = OktaJWKGeneratorMock(logger: OktaLoggerMock())
         jwtGenerator = OktaJWTGeneratorMock(logger: OktaLoggerMock())
         applicationConfig = ApplicationConfig(applicationName: "Test App",

--- a/Tests/DeviceAuthenticatorUnitTests/OktaFactorPushTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaFactorPushTests.swift
@@ -24,10 +24,10 @@ class OktaFactorPushTests: XCTestCase {
 
     override func setUp() {
         secKeyHelper = SecKeyHelperMock()
-        cryptoManager = CryptoManagerMock(accessGroupId: "", secKeyHelper: secKeyHelper, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: "", secKeyHelper: secKeyHelper, logger: OktaLoggerMock())
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [], dataArray: [])
         restAPIClient = LegacyServerAPI(client: mockHTTPClient,
-                                        crypto: OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId,
+                                        crypto: OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId,
                                                                   logger: OktaLoggerMock()),
                                         logger: OktaLoggerMock())
         factorData = OktaFactorMetadataPush(id: "id",

--- a/Tests/DeviceAuthenticatorUnitTests/OktaFactorTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaFactorTests.swift
@@ -16,7 +16,7 @@ import XCTest
 class OktaFactorTests: XCTestCase {
 
     func testCreation() {
-        let cryptoManager = CryptoManagerMock(accessGroupId: "", secKeyHelper: SecKeyHelperMock(), logger: OktaLoggerMock())
+        let cryptoManager = CryptoManagerMock(keychainGroupId: "", secKeyHelper: SecKeyHelperMock(), logger: OktaLoggerMock())
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [], dataArray: [])
         let restAPIClient = LegacyServerAPI(client: mockHTTPClient,
                                             crypto: cryptoManager,

--- a/Tests/DeviceAuthenticatorUnitTests/OktaJWTGeneratorIntegrationTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaJWTGeneratorIntegrationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import DeviceAuthenticator
 
 class OktaJWTGeneratorIntegrationTests: XCTestCase {
-    private let cryptoManager = OktaCryptoManager(accessGroupId: "", logger: OktaLoggerMock())
+    private let cryptoManager = OktaCryptoManager(keychainGroupId: "", logger: OktaLoggerMock())
     private var mut: OktaJWTGenerator!
     private let ec256ValidPrivateKeyBase64 = "BIBwuQyPfBPU+fyXiU+i0FOqEAHtm3U5aER8gIWVnyJvw9YfSa7ylqLNpdeyTie4zUFP9UU4FXLByqcaGFR1q05at441RDVAq1aewlvnE9pKcZmCiiayoO37AxpdRYcTmA=="
 

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSQLiteEncryptionManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSQLiteEncryptionManagerTests.swift
@@ -25,9 +25,9 @@ class OktaSQLiteEncryptionManagerTests: XCTestCase {
     }
 
     func encryptDecrypt(prefersSecureEnclaveUsage: Bool) {
-        let cryptoManager = OktaCryptoManager(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        let cryptoManager = OktaCryptoManager(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         let manager = OktaSQLiteEncryptionManager(cryptoManager: cryptoManager,
-                                                  accessGroupId: cryptoManager.accessGroupId)
+                                                  keychainGroupId: cryptoManager.keychainGroupId)
 
         let originalString = "Hello there"
         let originalStringData = originalString.data(using: .utf8)!

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
@@ -588,9 +588,9 @@ class OktaSharedSQLiteTests: XCTestCase {
         let logger = OktaLogger()
         let storage = try createStorage(prefersSecureEnclaveUsage: prefersSecureEnclaveUsage)
         #if os(iOS)
-        let crypto = OktaCryptoManager(accessGroupId: testGroupId, logger: logger)
+        let crypto = OktaCryptoManager(keychainGroupId: testGroupId, logger: logger)
         #else
-        let crypto = CryptoManagerMock(accessGroupId: testGroupId, logger: logger)
+        let crypto = CryptoManagerMock(keychainGroupId: testGroupId, logger: logger)
         #endif
         let restAPI = RestAPIMock(client: MockHTTPClient(), logger: logger)
         let config = ApplicationConfig(applicationName: "Test App",
@@ -599,7 +599,7 @@ class OktaSharedSQLiteTests: XCTestCase {
         return OktaSharedSQLite(sqlitePersistentStorage: storage,
                                 cryptoManager: crypto,
                                 restAPIClient: restAPI,
-                                sqliteColumnEncryptionManager: OktaSQLiteEncryptionManager(cryptoManager: crypto, accessGroupId: crypto.accessGroupId),
+                                sqliteColumnEncryptionManager: OktaSQLiteEncryptionManager(cryptoManager: crypto, keychainGroupId: crypto.keychainGroupId),
                                 applicationConfig: config,
                                 logger: logger)
     }

--- a/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
@@ -24,7 +24,7 @@ class OktaTransactionPushChallengeTests: XCTestCase {
     let ec256ValidPrivateKeyBase64 = "BIBwuQyPfBPU+fyXiU+i0FOqEAHtm3U5aER8gIWVnyJvw9YfSa7ylqLNpdeyTie4zUFP9UU4FXLByqcaGFR1q05at441RDVAq1aewlvnE9pKcZmCiiayoO37AxpdRYcTmA=="
 
     override func setUpWithError() throws {
-        cryptoManager = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         storageMock = StorageMock()
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [],
                                                             dataArray: [])
@@ -44,14 +44,14 @@ class OktaTransactionPushChallengeTests: XCTestCase {
             return TestUtils.createAuthenticatorEnrollment(orgHost: URL(string: "tenant.okta.com")!,
                                                            orgId: "orgId",
                                                            enrollmentId: "enrollmentId",
-                                                           cryptoManager: CryptoManagerMock(accessGroupId: "accessGroupId", logger: OktaLoggerMock()))
+                                                           cryptoManager: CryptoManagerMock(keychainGroupId: "accessGroupId", logger: OktaLoggerMock()))
         }
         let context = pushBindJWT!.jwt.payload["challengeContext"] as! [AnyHashable: Any]
         pushChallenge = PushChallenge(pushBindJWT: pushBindJWT!,
                                       challengeContext: context,
                                       storageManager: storageMock,
                                       applicationConfig: ApplicationConfig(applicationName: "", applicationVersion: "", applicationGroupId: ""),
-                                      cryptoManager: CryptoManagerMock(accessGroupId: "", logger: OktaLoggerMock()),
+                                      cryptoManager: CryptoManagerMock(keychainGroupId: "", logger: OktaLoggerMock()),
                                       signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                       restAPI: RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(), userAgent: ""), logger: OktaLoggerMock()),
                                       logger: OktaLoggerMock())

--- a/Tests/DeviceAuthenticatorUnitTests/PushChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/PushChallengeTests.swift
@@ -30,7 +30,7 @@ class PushChallengeTests: XCTestCase {
             return TestUtils.createAuthenticatorEnrollment(orgHost: URL(string: "tenant.okta.com")!,
                                                            orgId: "orgId",
                                                            enrollmentId: "enrollmentId",
-                                                           cryptoManager: CryptoManagerMock(accessGroupId: "accessGroupId", logger: OktaLoggerMock()))
+                                                           cryptoManager: CryptoManagerMock(keychainGroupId: "accessGroupId", logger: OktaLoggerMock()))
 
         }
         let context = pushBindJWT!.jwt.payload["challengeContext"] as! [AnyHashable: Any]
@@ -38,7 +38,7 @@ class PushChallengeTests: XCTestCase {
                                           challengeContext: context,
                                           storageManager: storageMock,
                                           applicationConfig: ApplicationConfig(applicationName: "", applicationVersion: "", applicationGroupId: ""),
-                                          cryptoManager: CryptoManagerMock(accessGroupId: "", logger: OktaLoggerMock()),
+                                          cryptoManager: CryptoManagerMock(keychainGroupId: "", logger: OktaLoggerMock()),
                                           signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                           restAPI: RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(),
                                                                                   userAgent: ""),
@@ -62,7 +62,7 @@ class PushChallengeTests: XCTestCase {
         XCTAssertNoThrow(try PushChallenge.parse(info: pushInfo,
                                                  allowedClockSkewInSeconds: 300,
                                                  validateJWT: false,
-                                                 accessGroupId: "",
+                                                 applicationGroupId: "",
                                                  logger: OktaLoggerMock()))
     }
 
@@ -72,7 +72,7 @@ class PushChallengeTests: XCTestCase {
         XCTAssertThrowsError(try PushChallenge.parse(info: pushInfo,
                                                      allowedClockSkewInSeconds: 300,
                                                      validateJWT: false,
-                                                     accessGroupId: "",
+                                                     applicationGroupId: "",
                                                      logger: OktaLoggerMock()))
     }
 
@@ -81,7 +81,7 @@ class PushChallengeTests: XCTestCase {
         XCTAssertThrowsError(try PushChallenge.parse(info: pushInfo,
                                                      allowedClockSkewInSeconds: 300,
                                                      validateJWT: false,
-                                                     accessGroupId: "",
+                                                     applicationGroupId: "",
                                                      logger: OktaLoggerMock()))
     }
 
@@ -97,7 +97,7 @@ class PushChallengeTests: XCTestCase {
                                           challengeContext: context,
                                           storageManager: storageMock,
                                           applicationConfig: ApplicationConfig(applicationName: "", applicationVersion: "", applicationGroupId: ""),
-                                          cryptoManager: CryptoManagerMock(accessGroupId: "", logger: OktaLoggerMock()),
+                                          cryptoManager: CryptoManagerMock(keychainGroupId: "", logger: OktaLoggerMock()),
                                           signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                           restAPI: RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(),
                                                                                   userAgent: ""),
@@ -119,7 +119,7 @@ class PushChallengeTests: XCTestCase {
                                           challengeContext: context,
                                           storageManager: storageMock,
                                           applicationConfig: ApplicationConfig(applicationName: "", applicationVersion: "", applicationGroupId: ""),
-                                          cryptoManager: CryptoManagerMock(accessGroupId: "", logger: OktaLoggerMock()),
+                                          cryptoManager: CryptoManagerMock(keychainGroupId: "", logger: OktaLoggerMock()),
                                           signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                           restAPI: RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(),
                                                                                   userAgent: ""),
@@ -141,7 +141,7 @@ class PushChallengeTests: XCTestCase {
                                           challengeContext: context,
                                           storageManager: storageMock,
                                           applicationConfig: ApplicationConfig(applicationName: "", applicationVersion: "", applicationGroupId: ""),
-                                          cryptoManager: CryptoManagerMock(accessGroupId: "", logger: OktaLoggerMock()),
+                                          cryptoManager: CryptoManagerMock(keychainGroupId: "", logger: OktaLoggerMock()),
                                           signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                           restAPI: RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(),
                                                                                   userAgent: ""),

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
@@ -33,7 +33,7 @@ class TransactionEnrollTests: XCTestCase {
 
     override func setUp() {
         secKeyHelperMock = SecKeyHelperMock()
-        cryptoManager = OktaCryptoManagerMock(accessGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
+        cryptoManager = OktaCryptoManagerMock(keychainGroupId: "", secKeyHelper: secKeyHelperMock, logger: OktaLoggerMock())
 
         let mockURL = URL(string: "https://example.okta.com")!
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [HTTPURLResponse(url: mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)!,

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
@@ -23,7 +23,7 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
     var deviceAuthenticator: DeviceAuthenticator!
 
     override func setUp() {
-        cryptoManager = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         restAPIMock = RestAPIMock(client: HTTPClient(logger: OktaLoggerMock(), userAgent: ""), logger: OktaLoggerMock())
         storageMock = StorageMock()
         storageMock.deviceEnrollmentByOrgIdHook = { orgId in

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPullChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPullChallengeTests.swift
@@ -35,15 +35,20 @@ class TransactionPullChallengeTests: XCTestCase {
     var restAPIClient: LegacyServerAPI!
     let entitiesGenerator = OktaStorageEntitiesGenerator()
     var storageMock: StorageMock!
+    var applicationConfig: ApplicationConfig!
 
     override func setUp() {
         secKeyHelper = SecKeyHelperMock()
-        cryptoManager = CryptoManagerMock(accessGroupId: "", secKeyHelper: secKeyHelper, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: "", secKeyHelper: secKeyHelper, logger: OktaLoggerMock())
         storageMock = StorageMock()
         let mockHTTPClient = MockMultipleRequestsHTTPClient(responseArray: [], dataArray: [])
         restAPIClient = LegacyServerAPI(client: mockHTTPClient,
                                         crypto: cryptoManager,
                                         logger: OktaLoggerMock())
+        applicationConfig = ApplicationConfig(applicationName: "AppName",
+                                              applicationVersion: "1.0.0",
+                                              applicationGroupId: "")
+        
     }
 
     func testPendingChallenge_Success() {
@@ -69,6 +74,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         var completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
@@ -96,6 +102,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                            storageManager: storageMock,
                                                                            cryptoManager: cryptoManager,
                                                                            restAPI: restAPIClient,
+                                                                           applicationConfig: applicationConfig,
                                                                            logger: OktaLoggerMock())
         completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
@@ -135,6 +142,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
@@ -183,6 +191,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
             switch result {
@@ -217,6 +226,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
             switch result {
@@ -251,6 +261,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
             switch result {
@@ -285,6 +296,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
             switch result {
@@ -319,6 +331,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                storageManager: storageMock,
                                                                                cryptoManager: cryptoManager,
                                                                                restAPI: restAPIClient,
+                                                                               applicationConfig: applicationConfig,
                                                                                logger: OktaLoggerMock())
         pullChallengeTransaction.pullChallenge(allowedClockSkewInSeconds: 300) { result in
             switch result {

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionTests.swift
@@ -22,7 +22,7 @@ class TransactionTests: XCTestCase {
     var deviceAuthenticator: DeviceAuthenticator!
 
     override func setUp() {
-        cryptoManager = CryptoManagerMock(accessGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
+        cryptoManager = CryptoManagerMock(keychainGroupId: ExampleAppConstants.appGroupId, logger: OktaLoggerMock())
         jwtGeneratorMock = OktaJWTGeneratorMock(logger: OktaLoggerMock())
         storageMock = StorageMock()
         deviceAuthenticator = try! DeviceAuthenticatorBuilder(applicationConfig: ApplicationConfig(applicationName: "",
@@ -47,7 +47,7 @@ class TransactionTests: XCTestCase {
     }
 
     func testGenerateAuthenticationJWTString_CantGetKey() {
-        let mut = OktaTransaction(loginHint: nil, storageManager: storageMock, cryptoManager: OktaCryptoManager(accessGroupId: "", logger: OktaLoggerMock()), jwtGenerator: nil, logger: OktaLoggerMock())
+        let mut = OktaTransaction(loginHint: nil, storageManager: storageMock, cryptoManager: OktaCryptoManager(keychainGroupId: "", logger: OktaLoggerMock()), jwtGenerator: nil, logger: OktaLoggerMock())
         let authenticator = TestUtils.createAuthenticatorEnrollment(orgHost: URL(string: "okta.okta.com")!,
                                                                     orgId: "orgId",
                                                                     enrollmentId: "enrollment_id",


### PR DESCRIPTION
### Problem Analysis (Technical)
MOV can't re-use application group id for sharing keychain data comparing to IOV. MOV needs to pass keychain group id during sdk initialize time

### Solution (Technical)
- Added support of keychain group id parameter in ApplicationConfig structure
- Internal components need to explicitly define which sharing capability they require: file sharing vs keychain sharing(applicationGroupId vs keychainGroupId)
- If keychain group id is not provided by the app then sdk falls back to application group id(iOS case)


### Affected Components
Crypto, Storage

