### PR TITLE
Enhance tests to validate push token transformation in requests

### DIFF
--- a/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentTestHelper.swift
+++ b/Tests/DeviceAuthenticatorFunctionalTests/EnrollmentTestHelper.swift
@@ -18,7 +18,7 @@ class EnrollmentTestHelper {
     private let authToken: AuthToken
     private var appConfig: ApplicationConfig!
     private var deviceAuthenticatorConfig: DeviceAuthenticatorConfig!
-    private var enrollmentParams: EnrollmentParameters!
+    var enrollmentParams: EnrollmentParameters!
     private(set) var deviceAuthenticator: DeviceAuthenticatorProtocol!
 
     init(applicationName: String,

--- a/Tests/DeviceAuthenticatorFunctionalTests/UpdateCIBAFlowTests.swift
+++ b/Tests/DeviceAuthenticatorFunctionalTests/UpdateCIBAFlowTests.swift
@@ -90,7 +90,6 @@ class UpdateCIBAFlowTests: XCTestCase {
             try enrollmentHelper.enroll(mockHTTPClient: mockHTTPClient) { result in
                 switch result {
                 case .success(let enrollment):
-                    let newDeviceTokenData = "12345abcde".data(using: .utf8)!
                     enrollment.enableCIBATransactions(authenticationToken: self.authToken, enable: true) { error in
                         if case .serverAPIError(let result, _) = error {
                             XCTAssertEqual(result.response?.statusCode, 401)


### PR DESCRIPTION
### Problem Analysis (Technical)
Since we don't have automations on real device to test push delivery we need to make sure that push token is always in expected format in http requests