### PR TITLE
OKTA-560810 - SDK sends `user_approved_consent_prompt` value for cons…

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceAuthenticatorConstants.swift
+++ b/Sources/DeviceAuthenticator/DeviceAuthenticatorConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 /// SDK constants
 public struct DeviceAuthenticatorConstants {
     /// DeviceAuthenticator SDK version
-    public static let version = "0.0.1"
+    public static let version = "0.0.2"
     /// DeviceAuthenticator SDK name
     public static let name = "DeviceAuthenticator"
     /// Location of shared SQLite database

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPushChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPushChallenge.swift
@@ -56,7 +56,9 @@ class OktaTransactionPushChallenge: OktaTransactionPossessionChallengeBase {
         }
 
         var keysRequirements = keysRequirements
-        transactionContext.userConsentResponseValue = pushChallenge.userResponse == .userApproved ? .approved : .denied
+        if pushChallenge.userResponse != .userApproved {
+            transactionContext.userConsentResponseValue = .denied
+        }
         if keyType == .userVerification && pushChallenge.userResponse == .userApproved {
             transactionContext.userConsentResponseValue = .approvedUserVerification
         } else {

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -227,7 +227,7 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         XCTAssertEqual(deviceSignalsModel.manufacturer, "APPLE")
         XCTAssertEqual(deviceSignalsModel.clientInstanceBundleId, "Test App")
         XCTAssertEqual(deviceSignalsModel.clientInstanceVersion, "1.0.0")
-        XCTAssertEqual(deviceSignalsModel.clientInstanceDeviceSdkVersion, "DeviceAuthenticator 0.0.1")
+        XCTAssertEqual(deviceSignalsModel.clientInstanceDeviceSdkVersion, "DeviceAuthenticator " + DeviceAuthenticatorConstants.version)
         XCTAssertNil(deviceSignalsModel.meid)
         XCTAssertNil(deviceSignalsModel.imei)
         XCTAssertNil(deviceSignalsModel.sid)


### PR DESCRIPTION
…ent property even if user cancelled biometric verification

### Problem Analysis (Technical)
SDK sends `.approved` consent value even if user cancels user verification

### Solution (Technical)
Fix the bug where child class overrode userConsentValue which was set by the base class