### PR TITLE
Add `UV_TEMPORARILY_UNAVAILABLE` consent value

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceAuthenticatorError.swift
+++ b/Sources/DeviceAuthenticator/DeviceAuthenticatorError.swift
@@ -141,6 +141,15 @@ extension DeviceAuthenticatorError {
         return false
     }
 
+    func userVerificationFailed() -> Bool {
+        if case .securityError(let encryptionErr) = self {
+            if case .localAuthenticationFailed(_) = encryptionErr {
+                return true
+            }
+        }
+        return false
+    }
+
     var serverErrorCode: ServerErrorCode? {
         if case .serverAPIError(_, let model) = self {
             return model?.errorCode

--- a/Sources/DeviceAuthenticator/Remediation/RemediationStepMessage.swift
+++ b/Sources/DeviceAuthenticator/Remediation/RemediationStepMessage.swift
@@ -33,6 +33,9 @@ public enum RemediationStepMessageReasonType: Int {
 
     /// SDK can't retrieve user verification key. Key might be missing or corrupted
     case userVerificationKeyCorruptedOrMissing
+
+    /// User failed local authentication process
+    case userVerificationFailed
 }
 
 ///  Step during verify flow to surface informational messages which don't require remediation

--- a/Sources/DeviceAuthenticator/SecurityError.swift
+++ b/Sources/DeviceAuthenticator/SecurityError.swift
@@ -24,6 +24,8 @@ public enum SecurityError: Error {
     case keyCorrupted(Error)
     /// Thrown when user cancels local authentication process via local authentication dialog
     case localAuthenticationCancelled(Error)
+    /// Thrown when user fails to authenticate via local authentication process
+    case localAuthenticationFailed(Error)
     /// Thrown for cases that can't be mapped to specific error domains. For example SDK failed to parse web token information
     case generalEncryptionError(OSStatus, Error?, String)
     /// Thrown when SDK fails to build JWK payload
@@ -41,6 +43,11 @@ public extension SecurityError {
         }
 
         let nsError: NSError = signingError as Error as NSError
+        let authFailedErrorCode = LAError.Code.authenticationFailed.rawValue // -1
+        if nsError.code == authFailedErrorCode && nsError.domain == LAErrorDomain {
+            return localAuthenticationFailed(nsError)
+        }
+
         let userCancelledErrorCode = LAError.Code.userCancel.rawValue // -2
         if nsError.code == userCancelledErrorCode && nsError.domain == LAErrorDomain {
             return localAuthenticationCancelled(nsError)

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -308,7 +308,6 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
 
             // Update consent value for cases where appropriate for error
             if skippedKey == .userVerification {
-                transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
                 if error.userVerificationCancelled() {
                     transactionContext.userConsentResponseValue = .cancelledUserVerification
                     // User cancelled biometric prompt and SDK fallbacks to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
@@ -317,6 +316,8 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     transactionContext.userConsentResponseValue = .userVerificationTemporarilyUnavailable
                     // Local authentication failed and SDK falls back to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
                     transactionContext.keyRequirements = [nextKey]
+                } else {
+                    transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
                 }
             }
             self.signJWTAndSendRequest(transactionContext: transactionContext,

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -315,8 +315,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     transactionContext.keyRequirements = [nextKey]
                 } else if error.userVerificationFailed() {
                     transactionContext.userConsentResponseValue = .userVerificationTemporarilyUnavailable
-                    // User failed biometric prompt, SDK should not fallback
-                    // to PoP key.
+                    // Local authentication failed and SDK falls back to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
                     transactionContext.keyRequirements = [nextKey]
                 }
             }

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -241,52 +241,20 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                                enrollment: transactionContext.enrollment,
                                userVerificationType: userVerificationType,
                                onIdentityStep: transactionContext.appIdentityStepClosure) { keyData, error in
-            let errorHandlingClosure: (DeviceAuthenticatorError) -> Void = { error in
-                if keysRequirements.count > 1 {
-                    // Fallback to next key in the array of key types
-                    var keyTypes = keysRequirements
-                    let skippedKey = keyTypes.removeFirst()
-                    let nextKey = keyTypes[0]
-
-                    var messageReason: RemediationStepMessageReasonType = .userVerificationKeyCorruptedOrMissing
-                    if case .securityError(let encErr) = error {
-                        if case .keyCorrupted(_) = encErr {
-                            messageReason = .userVerificationKeyCorruptedOrMissing
-                        } else if case .localAuthenticationCancelled(_) = encErr {
-                            messageReason = .userVerificationCancelledByUser
-                        }
-                    }
-                    // Surface the error via the non-blocking 'message' identity step
-                    self.postMessageToApplication(message: "Failed to sign with key \(skippedKey), falling back to \(nextKey)",
-                                                  reason: messageReason,
-                                                  error: error,
-                                                  transactionContext: transactionContext)
-
-                    // Update consent value for cases where appropriate for error
-                    if skippedKey == .userVerification {
-                        transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
-                        if error.userVerificationCancelled() {
-                            transactionContext.userConsentResponseValue = .cancelledUserVerification
-                            // User cancelled biometric prompt and SDK fallbacks to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
-                            transactionContext.keyRequirements = [nextKey]
-                        }
-                    }
-                    self.signJWTAndSendRequest(transactionContext: transactionContext,
-                                               keysRequirements: keyTypes)
-                } else {
-                    transactionContext.appCompletionClosure(nil, error, transactionContext.enrollment)
-                }
-            }
 
             if let error = error {
                 self.logger.error(eventName: self.logEventName, message: "Error: \(error)")
-                errorHandlingClosure(error)
+                self.readSigningKeyErrorHandler(error: error,
+                                                transactionContext: transactionContext,
+                                                keysRequirements: keysRequirements)
                 return
             }
             guard let keyData = keyData else {
                 let error = DeviceAuthenticatorError.internalError("Can't find encryption keys")
                 self.logger.error(eventName: self.logEventName, message: "Error: \(error)")
-                errorHandlingClosure(error)
+                self.readSigningKeyErrorHandler(error: error,
+                                                transactionContext: transactionContext,
+                                                keysRequirements: keysRequirements)
                 return
             }
             DispatchQueue.global().async {
@@ -305,9 +273,57 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                 } catch {
                     let error = DeviceAuthenticatorError.oktaError(from: error)
                     self.logger.error(eventName: self.logEventName, message: "Error: \(error)")
-                    errorHandlingClosure(error)
+                    self.readSigningKeyErrorHandler(error: error,
+                                                    transactionContext: transactionContext,
+                                                    keysRequirements: keysRequirements)
                 }
             }
+        }
+    }
+
+    private func readSigningKeyErrorHandler(error: DeviceAuthenticatorError,
+                                            transactionContext: TransactionContext,
+                                            keysRequirements: [OktaBindJWT.KeyType]) {
+        if keysRequirements.count > 1 {
+            // Fallback to next key in the array of key types
+            var keyTypes = keysRequirements
+            let skippedKey = keyTypes.removeFirst()
+            let nextKey = keyTypes[0]
+
+            var messageReason: RemediationStepMessageReasonType = .userVerificationKeyCorruptedOrMissing
+            if case .securityError(let encErr) = error {
+                if case .keyCorrupted(_) = encErr {
+                    messageReason = .userVerificationKeyCorruptedOrMissing
+                } else if case .localAuthenticationCancelled(_) = encErr {
+                    messageReason = .userVerificationCancelledByUser
+                } else if case .localAuthenticationFailed(_) = encErr {
+                    messageReason = .userVerificationFailed
+                }
+            }
+            // Surface the error via the non-blocking 'message' identity step
+            self.postMessageToApplication(message: "Failed to sign with key \(skippedKey), falling back to \(nextKey)",
+                                          reason: messageReason,
+                                          error: error,
+                                          transactionContext: transactionContext)
+
+            // Update consent value for cases where appropriate for error
+            if skippedKey == .userVerification {
+                transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
+                if error.userVerificationCancelled() {
+                    transactionContext.userConsentResponseValue = .cancelledUserVerification
+                    // User cancelled biometric prompt and SDK fallbacks to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
+                    transactionContext.keyRequirements = [nextKey]
+                } else if error.userVerificationFailed() {
+                    transactionContext.userConsentResponseValue = .userVerificationTemporarilyUnavailable
+                    // User failed biometric prompt, SDK should not fallback
+                    // to PoP key.
+                    transactionContext.keyRequirements = [nextKey]
+                }
+            }
+            self.signJWTAndSendRequest(transactionContext: transactionContext,
+                                       keysRequirements: keyTypes)
+        } else {
+            transactionContext.appCompletionClosure(nil, error, transactionContext.enrollment)
         }
     }
 

--- a/Sources/DeviceAuthenticator/Transactions/OktaUserConsentValue.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaUserConsentValue.swift
@@ -17,6 +17,7 @@ enum OktaUserConsentValue: String {
     case denied = "DENIED_CONSENT_PROMPT"
     case approvedUserVerification = "APPROVED_USER_VERIFICATION"
     case cancelledUserVerification = "CANCELLED_USER_VERIFICATION"
+    case userVerificationTemporarilyUnavailable = "UV_TEMPORARILY_UNAVAILABLE"
     case none = "NONE"
 
     static func create(_ response: UserConsentResponse) -> OktaUserConsentValue {


### PR DESCRIPTION
### Problem Analysis (Technical)

The SDK was ignoring LAError.authenticationFailed which caused biometric failures to trigger a fallback to simple UserConsent.

### Solution (Technical)

A new user consent value (`UV_TEMPORARILY_UNAVAILABLE`) was added and will be sent in cases where local authentication fails.

### Affected Components
FP Challenges

### Steps to reproduce:
1. Attempt FP authentication on macOS
2. Repeatedly use invalid fingerprint when prompted for biometrics.

Actual result: SDK falls back to using simple user consent

Expected result: SDK should abort authentication flow

### Tests
I tested manually, but I didn't see a way to mock LAContext or the Keychain in the existing code. If I'm mistaken, or you'd like me to add a way, let me know.