### PR TITLE
OKTA-564428 - Add timeout configuration value for concurrent SQLIte requests to reduce probability of SQLITE_BUSY errors

### DIFF
--- a/Sources/DeviceAuthenticator/Storage/OktaStorageManager.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaStorageManager.swift
@@ -79,7 +79,7 @@ class OktaStorageManager: PersistentStorageProtocol {
         let fileName = DeviceAuthenticatorConstants.defaultStorageName
         let sqliteEncryptionManager = OktaSQLiteEncryptionManager(cryptoManager: cryptoManager,
                                                                   keychainGroupId: applicationConfig.applicationInfo.keychainGroupId)
-        let sqliteStorage = try OktaSQLitePersistentStorage.sqlitePersistentStorage(schemaVersion: Self.targetVersion,
+        let sqliteStorage = try OktaSQLitePersistentStorage.sqlitePersistentStorage(schemaVersion: SQLiteStorageVersion.latestVersion,
                                                                                     storageRelativePath: "\(path)/\(fileName)",
                                                                                     applicationGroupId: applicationConfig.applicationInfo.applicationGroupId,
                                                                                     sqliteFileEncryptionKey: nil,
@@ -93,9 +93,6 @@ class OktaStorageManager: PersistentStorageProtocol {
 
         return sqliteStorageManager
     }
-
-    // MARK: Versioning and Migraiton
-    public static let targetVersion = SQLiteStorageVersion.v1
 }
 
 extension OktaStorageManager: OktaEnrollmentStorageProtocol {

--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSQLIteConnectionBuilder.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSQLIteConnectionBuilder.swift
@@ -29,6 +29,7 @@ class OktaSQLiteConnectionBuilder: OktaSQLiteConnectionBuilderProtocol {
 
     private func databasePool(at databaseURL: URL, sqliteFileEncryptionKey: Data?) throws -> DatabasePool {
         var configuration = Configuration()
+        configuration.busyMode = .timeout(1) // retry in 1 second if write failed with SQLITE_BUSY error(other process locked db/table)
         configuration.prepareDatabase { db in
             // Activate the persistent WAL mode so that
             // readonly processes can access the database.

--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
@@ -46,7 +46,7 @@ class OktaSharedSQLite: OktaSharedSQLiteProtocol {
     }
 
     // MARK: Versioning and Migraiton
-    public static let targetVersion = SQLiteStorageVersion.v1
+    public static let targetVersion = SQLiteStorageVersion.latestVersion
     public var lastKnownVersion: Version {
         if !sqlitePersistentStorage.sqliteFileExist() {
             // if there is no SQLite stored yet, return Self.targetVersion right away to avoid

--- a/Sources/DeviceAuthenticator/Storage/SQLite/SQLiteStorageVersion.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/SQLiteStorageVersion.swift
@@ -17,4 +17,9 @@ enum SQLiteStorageVersion: Int, OktaVersionType {
     case v1 = 1
 
     static var unknownVersion: SQLiteStorageVersion { return .unknown }
+
+    static var latestVersion: Self {
+        let allCases = Self.allCases.sorted()
+        return allCases.last ?? .unknown
+    }
 }


### PR DESCRIPTION
### Problem Analysis (Technical)
Add `configuration.busyMode = .timeout(1)` to sqlite configuration. This allows grdb to wait for 1 second before retrying in case if write operation returned SQLITE_BUSY error