### PR TITLE
Create new error code for PostMessage event - userVerificationKeyNotE…

### DIFF
--- a/Sources/DeviceAuthenticator/Remediation/RemediationStepMessage.swift
+++ b/Sources/DeviceAuthenticator/Remediation/RemediationStepMessage.swift
@@ -28,6 +28,9 @@ public enum RemediationStepMessageType: Int {
 
 ///  Reason of why message was sent from SDK side
 public enum RemediationStepMessageReasonType: Int {
+    /// User verification key is not enrolled for account
+    case userVerificationKeyNotEnrolled
+
     /// User cancelled local authentication process
     case userVerificationCancelledByUser
 

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -290,7 +290,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
             let skippedKey = keyTypes.removeFirst()
             let nextKey = keyTypes[0]
 
-            var messageReason: RemediationStepMessageReasonType = .userVerificationKeyCorruptedOrMissing
+            var messageReason: RemediationStepMessageReasonType = .userVerificationKeyNotEnrolled
             if case .securityError(let encErr) = error {
                 if case .keyCorrupted(_) = encErr {
                     messageReason = .userVerificationKeyCorruptedOrMissing

--- a/Tests/DeviceAuthenticatorFunctionalTests/VerifyFlowTests.swift
+++ b/Tests/DeviceAuthenticatorFunctionalTests/VerifyFlowTests.swift
@@ -703,7 +703,7 @@ class VerifyFlowTests: XCTestCase {
                                 userConsentStep.provide(.approved)
                                 isUserConsentStepCall = true
                             case let messageStep as RemediationStepMessage:
-                                XCTAssertEqual(messageStep.reasonType, .userVerificationKeyCorruptedOrMissing)
+                                XCTAssertEqual(messageStep.reasonType, .userVerificationKeyNotEnrolled)
                                 isMessageStepCall = true
                             default:
                                 XCTFail()
@@ -753,7 +753,7 @@ class VerifyFlowTests: XCTestCase {
                                 userConsentStep.provide(.approved)
                                 isUserConsentStepCall = true
                             case let messageStep as RemediationStepMessage:
-                                XCTAssertEqual(messageStep.reasonType, .userVerificationKeyCorruptedOrMissing)
+                                XCTAssertEqual(messageStep.reasonType, .userVerificationKeyNotEnrolled)
                                 isMessageStepCall = true
                             default:
                                 XCTFail()

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
@@ -247,7 +247,7 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
     }
 
     func testReadSigningKeyErrorHandler() throws {
-        let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+        var mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
                                                                         challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
                                                                         stateHandle: "state_handle",
                                                                         httpHeaders: nil,
@@ -257,7 +257,7 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                                                         signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                                                         restAPI: restAPIMock,
                                                                         logger: OktaLoggerMock())
-        let transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+        var transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
                                                                                            appIdentityStepClosure: { step in
         },
                                                                                            appCompletionClosure: { jwt, error, enrollment in
@@ -280,6 +280,21 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
 
+        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+                                                                                           appIdentityStepClosure: { step in
+        },
+                                                                                           appCompletionClosure: { jwt, error, enrollment in
+        })
+        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                    stateHandle: "state_handle",
+                                                                    httpHeaders: nil,
+                                                                    loginHint: nil,
+                                                                    storageManager: storageMock,
+                                                                    cryptoManager: cryptoManager,
+                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                    restAPI: restAPIMock,
+                                                                    logger: OktaLoggerMock())
         signJWTAndSendRequestHookCalled = false
         postMessageToApplicationHookCalled = false
         mut.postMessageToApplicationHook = { message, reasonType, error, context in
@@ -297,6 +312,21 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
 
+        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+                                                                                           appIdentityStepClosure: { step in
+        },
+                                                                                           appCompletionClosure: { jwt, error, enrollment in
+        })
+        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                    stateHandle: "state_handle",
+                                                                    httpHeaders: nil,
+                                                                    loginHint: nil,
+                                                                    storageManager: storageMock,
+                                                                    cryptoManager: cryptoManager,
+                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                    restAPI: restAPIMock,
+                                                                    logger: OktaLoggerMock())
         signJWTAndSendRequestHookCalled = false
         postMessageToApplicationHookCalled = false
         mut.postMessageToApplicationHook = { message, reasonType, error, context in
@@ -309,6 +339,38 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
             signJWTAndSendRequestHookCalled = true
         }
         mut.readSigningKeyErrorHandler(error: .securityError(.localAuthenticationCancelled(NSError())),
+                                       transactionContext: transactionContext,
+                                       keysRequirements: [.userVerification, .proofOfPossession])
+        XCTAssertTrue(signJWTAndSendRequestHookCalled)
+        XCTAssertTrue(postMessageToApplicationHookCalled)
+
+        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+                                                                                           appIdentityStepClosure: { step in
+        },
+                                                                                           appCompletionClosure: { jwt, error, enrollment in
+        })
+        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                    stateHandle: "state_handle",
+                                                                    httpHeaders: nil,
+                                                                    loginHint: nil,
+                                                                    storageManager: storageMock,
+                                                                    cryptoManager: cryptoManager,
+                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                    restAPI: restAPIMock,
+                                                                    logger: OktaLoggerMock())
+        signJWTAndSendRequestHookCalled = false
+        postMessageToApplicationHookCalled = false
+        mut.postMessageToApplicationHook = { message, reasonType, error, context in
+            XCTAssertEqual(message, "Failed to sign with key userVerification, falling back to proofOfPossession")
+            XCTAssertEqual(reasonType, .userVerificationKeyNotEnrolled)
+            postMessageToApplicationHookCalled = true
+        }
+        mut.signJWTAndSendRequestHook = { context, keyTypes in
+            XCTAssertTrue(context.userConsentResponseValue == .approved)
+            signJWTAndSendRequestHookCalled = true
+        }
+        mut.readSigningKeyErrorHandler(error: .genericError("UV key is not found for account"),
                                        transactionContext: transactionContext,
                                        keysRequirements: [.userVerification, .proofOfPossession])
         XCTAssertTrue(signJWTAndSendRequestHookCalled)


### PR DESCRIPTION
…nrolled

### Problem Analysis (Technical)
New error condition can be useful for app layer to know that SDK tried to use UV key for transaction but UV key is not enrolled for account