### PR TITLE
Create new error code for PostMessage event - userVerificationKeyNotE…

### DIFF
--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -321,7 +321,12 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     // Local authentication failed and SDK falls back to PoP key. Set keyRequirements in transactionContext to avoid sending of unnecessary user consent screen event
                     transactionContext.keyRequirements = [nextKey]
                 } else {
-                    transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
+                    if transactionContext.challengeRequest.userVerification == .required {
+                        transactionContext.userConsentResponseValue = .userVerificationPermanentlyUnavailable
+                        transactionContext.keyRequirements = [nextKey]
+                    } else {
+                        transactionContext.userConsentResponseValue = transactionContext.userConsentResponseValue.userVerificationFailed()
+                    }
                 }
             }
             self.signJWTAndSendRequest(transactionContext: transactionContext,


### PR DESCRIPTION
…nrolled

### Problem Analysis (Technical)
SDK sends user consent screen for UV-required transaction when uv key is not enrolled

### Solution (Technical)
Don't send UC event and set userConsent value to `userVerificationPermanentlyUnavailable `

