### PR TITLE
Fix missing teamIdentifier and incorrect OS version for userAgent string on macOS

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - DeviceAuthenticator (0.0.2):
+  - DeviceAuthenticator (0.0.3):
     - GRDB.swift (~> 5)
     - OktaJWT (~> 2.3)
     - OktaLogger/FileLogger (~> 1)
@@ -39,7 +39,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  DeviceAuthenticator: cbb7c5019ab3b74dd4f97dba3ae92526e275b82a
+  DeviceAuthenticator: bebff0c446ea08793a4f68581407c2ee94012672
   GRDB.swift: e98cd55ec99dea5da99355d588149063e4cfa0eb
   OktaJWT: d9934b947fd0742713557b9ab9e1a313d40751cc
   OktaLogger: 7788647b3748015cc367e3b767d40b0c9e3a391a

--- a/Sources/DeviceAuthenticator/Networking/UserAgent.swift
+++ b/Sources/DeviceAuthenticator/Networking/UserAgent.swift
@@ -76,11 +76,12 @@ class UserAgent: NSObject, UserAgentProtocol {
     }
 
     class func platformInfo() -> String {
-        #if os(iOS)
-                return "iOS/\(UIDevice.current.systemVersion)"
-        #elseif os(OSX)
-                return "macOS/\(ProcessInfo.processInfo.operatingSystemVersionString))"
-        #endif
+#if os(iOS)
+        return "iOS/\(UIDevice.current.systemVersion)"
+#elseif os(OSX)
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "macOS/\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+#endif
     }
 
     class func deviceInfo() -> String {

--- a/Sources/DeviceAuthenticator/Utils/OktaBundleProperties.swift
+++ b/Sources/DeviceAuthenticator/Utils/OktaBundleProperties.swift
@@ -18,12 +18,16 @@ extension Bundle {
      Return the team identifier from the keychain entitlements (e.g. "B7F62B65BN")
      */
     static var teamIdentifier: String? = {
-        let queryLoad: [String: AnyObject] = [
+        var queryLoad: [String: AnyObject] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: "bundleSeedID" as AnyObject,
             kSecAttrService as String: "" as AnyObject,
             kSecReturnAttributes as String: kCFBooleanTrue
         ]
+
+        if #available(macOS 10.15, iOS 13.0, *) {
+            queryLoad[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
+        }
 
         var result: AnyObject?
         var status = withUnsafeMutablePointer(to: &result) {

--- a/Sources/DeviceAuthenticator/Utils/OktaBundleProperties.swift
+++ b/Sources/DeviceAuthenticator/Utils/OktaBundleProperties.swift
@@ -25,9 +25,11 @@ extension Bundle {
             kSecReturnAttributes as String: kCFBooleanTrue
         ]
 
-        if #available(macOS 10.15, iOS 13.0, *) {
+#if os(macOS)
+        if #available(macOS 10.15, *) {
             queryLoad[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
         }
+#endif
 
         var result: AnyObject?
         var status = withUnsafeMutablePointer(to: &result) {


### PR DESCRIPTION
### Problem Analysis (Technical)
- No team identifier produced for userAgent string on macOS.
- Full macOS version description produced for userAgent on macOS instead of short version string
**ProcessInfo.processInfo.operatingSystemVersionString** output is smth like **Version 12.6.2 (Build 21G320)), 12.6.2**

### Solution (Technical)
- Added [kSecUseDataProtectionKeychain](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain) key to the keychain query to obtain [kSecAttrAccessGroup](https://developer.apple.com/documentation/security/ksecattraccessgroup) value, which contains the team identifier.
- Invoke **ProcessInfo.processInfo.operatingSystemVersion** API to get all the OS version components and properly construct version string.
