### PR TITLE
Add authorizationServerId parameter to retrieveMaintenanceToken API

### DIFF
--- a/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
+++ b/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
@@ -66,8 +66,10 @@ public protocol AuthenticatorEnrollmentProtocol {
     /// Retrieves maintenace access token for enrollment update and read operations
     /// - Parameters:
     ///   - scopes: Array of requested scopes, for example ["okta.myAccount.appAuthenticator.maintenance.read", "okta.myAccount.appAuthenticator.maintenance.manage"]
+    ///   - authorizationServerId: Authorization server id. Pass nil if you are using Okta organization server. Pass "default" if you use default custom authorization server
     ///   - completion: Callback for asynchronous operation, returns acess token or error
     func retrieveMaintenanceToken(scopes: [String],
+                                  authorizationServerId: String?,
                                   completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void)
 }
 
@@ -80,8 +82,10 @@ public extension AuthenticatorEnrollmentProtocol {
                                completion: completion)
     }
 
-    func retrieveMaintenanceToken(completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
+    func retrieveMaintenanceToken(authorizationServerId: String?,
+                                  completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
         retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage"],
+                                 authorizationServerId: authorizationServerId,
                                  completion: completion)
     }
 }

--- a/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
@@ -277,6 +277,7 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
     }
 
     func retrieveMaintenanceToken(scopes: [String],
+                                  authorizationServerId: String?,
                                   completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
         guard let policy = try? storageManager.authenticatorPolicyForOrgId(organization.id) as? AuthenticatorPolicy else {
             completion(.failure(DeviceAuthenticatorError.genericError("Failed to fetch authenticator policy")))
@@ -311,6 +312,7 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
 
         logger.info(eventName: logEventName, message: "Requesting maintenance token with client_id = \(oidcClientId)")
         restAPIClient.retrieveMaintenanceToken(with: orgHost,
+                                               authorizationServerId: authorizationServerId,
                                                oidcClientId: oidcClientId,
                                                scopes: scopes,
                                                assertion: assertion) { result in

--- a/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
@@ -89,6 +89,7 @@ protocol ServerAPIProtocol {
                           completion: @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void)
 
     func retrieveMaintenanceToken(with orgURL: URL,
+                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
@@ -158,16 +159,23 @@ extension ServerAPIProtocol {
     /// - Description: Retrieves maintenace access token for update and read operations
     /// - Parameters:
     ///   - orgURL:         Org host url
+    ///   - authorizationServerId: Authorization server id. Pass nil if you are using Okta organization server. Pass "default" if you use default custom authorization server
     ///   - oidcClientId:   OIDC client_id
     ///   - scopes:         Requested scopes
     ///   - assertion:      JWT assertion that client exchanges for access token
     ///   - completion:     Handler to execute after the async call completes
     func retrieveMaintenanceToken(with orgURL: URL,
+                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
                                   completion: @escaping (Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) {
-        let completeURL = orgURL.appendingPathComponent("/oauth2/v1/token")
+        let completeURL: URL
+        if let authorizationServerId = authorizationServerId {
+            completeURL = orgURL.appendingPathComponent("/oauth2/\(authorizationServerId)/v1/token")
+        } else {
+            completeURL = orgURL.appendingPathComponent("/oauth2/v1/token")
+        }
         let contentTypeHeaderValue = "application/x-www-form-urlencoded"
         let acceptHeaderValue = "application/json"
         let grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -333,7 +333,8 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var retrieveMaintenaceTokenHookCalled = false
-        restAPIMock.retrieveMaintenaceTokenHook = { url, oidcClientId, scopes, assertion, completion in
+        restAPIMock.retrieveMaintenaceTokenHook = { url, authorizationServerId, oidcClientId, scopes, assertion, completion in
+            XCTAssertEqual(authorizationServerId, "default")
             retrieveMaintenaceTokenHookCalled = true
             XCTAssertEqual(url, self.enrollment.orgHost)
             XCTAssertEqual(oidcClientId, policy.metadata.settings?.oauthClientId ?? "")
@@ -354,7 +355,8 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         let opaqueEnrollment = enrollment as AuthenticatorEnrollmentProtocol
         var retrieveMaintenanceTokenCallbackCalled = false
         opaqueEnrollment.retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage",
-                                                          "okta.myAccount.appAuthenticator.maintenance.read"]) { result in
+                                                          "okta.myAccount.appAuthenticator.maintenance.read"],
+                                                  authorizationServerId: "default") { result in
             switch result {
             case .failure(_):
                 XCTFail("Unexpected failure")
@@ -385,7 +387,8 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var retrieveMaintenaceTokenHookCalled = false
-        restAPIMock.retrieveMaintenaceTokenHook = { url, oidcClientId, scopes, assertion, completion in
+        restAPIMock.retrieveMaintenaceTokenHook = { url, authorizationServerId, oidcClientId, scopes, assertion, completion in
+            XCTAssertNil(authorizationServerId)
             retrieveMaintenaceTokenHookCalled = true
             let httpResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
             completion(.success(HTTPURLResult(request: nil, response: httpResponse, data: nil, error: nil)))
@@ -394,7 +397,8 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         let opaqueEnrollment = enrollment as AuthenticatorEnrollmentProtocol
         var retrieveMaintenanceTokenCallbackCalled = false
         opaqueEnrollment.retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage",
-                                                          "okta.myAccount.appAuthenticator.maintenance.read"]) { result in
+                                                          "okta.myAccount.appAuthenticator.maintenance.read"],
+                                                  authorizationServerId: nil) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -5)

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -25,7 +25,7 @@ class RestAPIMock: ServerAPIProtocol {
     typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void) -> Void
     typealias deleteAuthenticatorRequestType = (AuthenticatorEnrollment, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias pendingChallengeRequestType = (URL, OktaRestAPIToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
-    typealias retrieveMaintenaceTokenType = (URL, String, [String], String,(Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) -> Void
+    typealias retrieveMaintenaceTokenType = (URL, String?, String, [String], String,(Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) -> Void
 
     var enrollAuthenticatorRequestHook: enrollAuthenticatorRequestType?
     var downloadOrgIdTypeHook: downloadOrgIdType?
@@ -161,14 +161,16 @@ class RestAPIMock: ServerAPIProtocol {
     }
 
     func retrieveMaintenanceToken(with orgURL: URL,
+                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
                                   completion: @escaping (Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) {
         if let retrieveMaintenaceTokenHook = retrieveMaintenaceTokenHook {
-            retrieveMaintenaceTokenHook(orgURL, oidcClientId, scopes, assertion, completion)
+            retrieveMaintenaceTokenHook(orgURL, authorizationServerId, oidcClientId, scopes, assertion, completion)
         } else {
             restAPI.retrieveMaintenanceToken(with: orgURL,
+                                             authorizationServerId: authorizationServerId,
                                              oidcClientId: oidcClientId,
                                              scopes: scopes,
                                              assertion: assertion,

--- a/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
@@ -606,7 +606,7 @@ final class MyAccountServerAPITests: XCTestCase {
         let httpClient = MockHTTPClient(result: httpResult)
         let expectedCredential = try JSONDecoder().decode(Oauth2Credential.self, from: MyAccountTestData.accessTokenResponse())
         httpClient.requestHook = { url, httpMethod, urlParameters, data, httpHeaders, timeInterval in
-            XCTAssertEqual(url.absoluteString, "https://example.okta.com/oauth2/v1/token")
+            XCTAssertEqual(url.absoluteString, "https://example.okta.com/oauth2/default/v1/token")
             XCTAssertTrue(httpMethod == .get)
             XCTAssertEqual(httpHeaders["Content-Type"], "application/x-www-form-urlencoded")
             XCTAssertEqual(httpHeaders["Accept"], "application/json")
@@ -618,7 +618,11 @@ final class MyAccountServerAPITests: XCTestCase {
         }
         let myAccountAPI = MyAccountServerAPI(client: httpClient, crypto: crypto, logger: OktaLoggerMock())
         var closureCalled = false
-        myAccountAPI.retrieveMaintenanceToken(with: mockURL, oidcClientId: "oidcClientId", scopes: ["some.scope"], assertion: "assertion") { result in
+        myAccountAPI.retrieveMaintenanceToken(with: mockURL,
+                                              authorizationServerId: "default",
+                                              oidcClientId: "oidcClientId",
+                                              scopes: ["some.scope"],
+                                              assertion: "assertion") { result in
             switch result {
             case .failure(_):
                 XCTFail("Unexpected failure")
@@ -641,12 +645,17 @@ final class MyAccountServerAPITests: XCTestCase {
                                        data: Data())
         let httpClient = MockHTTPClient(result: httpResult)
         httpClient.requestHook = { url, httpMethod, urlParameters, data, httpHeaders, timeInterval in
+            XCTAssertEqual(url.absoluteString, "https://example.okta.com/oauth2/v1/token")
             let mockURLRequest = MockURLRequest(result: httpResult, headers: httpHeaders)
             return mockURLRequest
         }
         let myAccountAPI = MyAccountServerAPI(client: httpClient, crypto: crypto, logger: OktaLoggerMock())
         var closureCalled = false
-        myAccountAPI.retrieveMaintenanceToken(with: mockURL, oidcClientId: "oidcClientId", scopes: ["some.scope"], assertion: "assertion") { result in
+        myAccountAPI.retrieveMaintenanceToken(with: mockURL,
+                                              authorizationServerId: nil,
+                                              oidcClientId: "oidcClientId",
+                                              scopes: ["some.scope"],
+                                              assertion: "assertion") { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -1)


### PR DESCRIPTION
### Problem Analysis (Technical)
Add authorizationServerId parameter to retrieveMaintenanceToken API