### PR TITLE
Remove authorization server id from maintenance token API

### DIFF
--- a/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
+++ b/Sources/DeviceAuthenticator/AuthenticatorEnrollmentProtocol.swift
@@ -69,7 +69,6 @@ public protocol AuthenticatorEnrollmentProtocol {
     ///   - authorizationServerId: Authorization server id. Pass nil if you are using Okta organization server. Pass "default" if you use default custom authorization server
     ///   - completion: Callback for asynchronous operation, returns acess token or error
     func retrieveMaintenanceToken(scopes: [String],
-                                  authorizationServerId: String?,
                                   completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void)
 }
 
@@ -82,10 +81,8 @@ public extension AuthenticatorEnrollmentProtocol {
                                completion: completion)
     }
 
-    func retrieveMaintenanceToken(authorizationServerId: String?,
-                                  completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
+    func retrieveMaintenanceToken(completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
         retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage"],
-                                 authorizationServerId: authorizationServerId,
                                  completion: completion)
     }
 }

--- a/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
@@ -277,7 +277,6 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
     }
 
     func retrieveMaintenanceToken(scopes: [String],
-                                  authorizationServerId: String?,
                                   completion: @escaping (Result<Oauth2Credential, DeviceAuthenticatorError>) -> Void) {
         guard let policy = try? storageManager.authenticatorPolicyForOrgId(organization.id) as? AuthenticatorPolicy else {
             completion(.failure(DeviceAuthenticatorError.genericError("Failed to fetch authenticator policy")))
@@ -312,7 +311,6 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
 
         logger.info(eventName: logEventName, message: "Requesting maintenance token with client_id = \(oidcClientId)")
         restAPIClient.retrieveMaintenanceToken(with: orgHost,
-                                               authorizationServerId: authorizationServerId,
                                                oidcClientId: oidcClientId,
                                                scopes: scopes,
                                                assertion: assertion) { result in

--- a/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
@@ -89,7 +89,6 @@ protocol ServerAPIProtocol {
                           completion: @escaping (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void)
 
     func retrieveMaintenanceToken(with orgURL: URL,
-                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
@@ -165,17 +164,11 @@ extension ServerAPIProtocol {
     ///   - assertion:      JWT assertion that client exchanges for access token
     ///   - completion:     Handler to execute after the async call completes
     func retrieveMaintenanceToken(with orgURL: URL,
-                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
                                   completion: @escaping (Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) {
-        let completeURL: URL
-        if let authorizationServerId = authorizationServerId {
-            completeURL = orgURL.appendingPathComponent("/oauth2/\(authorizationServerId)/v1/token")
-        } else {
-            completeURL = orgURL.appendingPathComponent("/oauth2/v1/token")
-        }
+        let completeURL = orgURL.appendingPathComponent("/oauth2/v1/token")
         let contentTypeHeaderValue = "application/x-www-form-urlencoded"
         let acceptHeaderValue = "application/json"
         let grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -333,8 +333,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var retrieveMaintenaceTokenHookCalled = false
-        restAPIMock.retrieveMaintenaceTokenHook = { url, authorizationServerId, oidcClientId, scopes, assertion, completion in
-            XCTAssertEqual(authorizationServerId, "default")
+        restAPIMock.retrieveMaintenaceTokenHook = { url, oidcClientId, scopes, assertion, completion in
             retrieveMaintenaceTokenHookCalled = true
             XCTAssertEqual(url, self.enrollment.orgHost)
             XCTAssertEqual(oidcClientId, policy.metadata.settings?.oauthClientId ?? "")
@@ -355,8 +354,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         let opaqueEnrollment = enrollment as AuthenticatorEnrollmentProtocol
         var retrieveMaintenanceTokenCallbackCalled = false
         opaqueEnrollment.retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage",
-                                                          "okta.myAccount.appAuthenticator.maintenance.read"],
-                                                  authorizationServerId: "default") { result in
+                                                           "okta.myAccount.appAuthenticator.maintenance.read"]) { result in
             switch result {
             case .failure(_):
                 XCTFail("Unexpected failure")
@@ -387,8 +385,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var retrieveMaintenaceTokenHookCalled = false
-        restAPIMock.retrieveMaintenaceTokenHook = { url, authorizationServerId, oidcClientId, scopes, assertion, completion in
-            XCTAssertNil(authorizationServerId)
+        restAPIMock.retrieveMaintenaceTokenHook = { url, oidcClientId, scopes, assertion, completion in
             retrieveMaintenaceTokenHookCalled = true
             let httpResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
             completion(.success(HTTPURLResult(request: nil, response: httpResponse, data: nil, error: nil)))
@@ -397,8 +394,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         let opaqueEnrollment = enrollment as AuthenticatorEnrollmentProtocol
         var retrieveMaintenanceTokenCallbackCalled = false
         opaqueEnrollment.retrieveMaintenanceToken(scopes: ["okta.myAccount.appAuthenticator.maintenance.manage",
-                                                          "okta.myAccount.appAuthenticator.maintenance.read"],
-                                                  authorizationServerId: nil) { result in
+                                                           "okta.myAccount.appAuthenticator.maintenance.read"]) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -5)

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -25,7 +25,7 @@ class RestAPIMock: ServerAPIProtocol {
     typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void) -> Void
     typealias deleteAuthenticatorRequestType = (AuthenticatorEnrollment, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias pendingChallengeRequestType = (URL, OktaRestAPIToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
-    typealias retrieveMaintenaceTokenType = (URL, String?, String, [String], String,(Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) -> Void
+    typealias retrieveMaintenaceTokenType = (URL, String, [String], String,(Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) -> Void
 
     var enrollAuthenticatorRequestHook: enrollAuthenticatorRequestType?
     var downloadOrgIdTypeHook: downloadOrgIdType?
@@ -161,16 +161,14 @@ class RestAPIMock: ServerAPIProtocol {
     }
 
     func retrieveMaintenanceToken(with orgURL: URL,
-                                  authorizationServerId: String?,
                                   oidcClientId: String,
                                   scopes: [String],
                                   assertion: String,
                                   completion: @escaping (Result<HTTPURLResult, DeviceAuthenticatorError>) -> Void) {
         if let retrieveMaintenaceTokenHook = retrieveMaintenaceTokenHook {
-            retrieveMaintenaceTokenHook(orgURL, authorizationServerId, oidcClientId, scopes, assertion, completion)
+            retrieveMaintenaceTokenHook(orgURL, oidcClientId, scopes, assertion, completion)
         } else {
             restAPI.retrieveMaintenanceToken(with: orgURL,
-                                             authorizationServerId: authorizationServerId,
                                              oidcClientId: oidcClientId,
                                              scopes: scopes,
                                              assertion: assertion,

--- a/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
@@ -606,7 +606,7 @@ final class MyAccountServerAPITests: XCTestCase {
         let httpClient = MockHTTPClient(result: httpResult)
         let expectedCredential = try JSONDecoder().decode(Oauth2Credential.self, from: MyAccountTestData.accessTokenResponse())
         httpClient.requestHook = { url, httpMethod, urlParameters, data, httpHeaders, timeInterval in
-            XCTAssertEqual(url.absoluteString, "https://example.okta.com/oauth2/default/v1/token")
+            XCTAssertEqual(url.absoluteString, "https://example.okta.com/oauth2/v1/token")
             XCTAssertTrue(httpMethod == .get)
             XCTAssertEqual(httpHeaders["Content-Type"], "application/x-www-form-urlencoded")
             XCTAssertEqual(httpHeaders["Accept"], "application/json")
@@ -619,7 +619,6 @@ final class MyAccountServerAPITests: XCTestCase {
         let myAccountAPI = MyAccountServerAPI(client: httpClient, crypto: crypto, logger: OktaLoggerMock())
         var closureCalled = false
         myAccountAPI.retrieveMaintenanceToken(with: mockURL,
-                                              authorizationServerId: "default",
                                               oidcClientId: "oidcClientId",
                                               scopes: ["some.scope"],
                                               assertion: "assertion") { result in
@@ -652,7 +651,6 @@ final class MyAccountServerAPITests: XCTestCase {
         let myAccountAPI = MyAccountServerAPI(client: httpClient, crypto: crypto, logger: OktaLoggerMock())
         var closureCalled = false
         myAccountAPI.retrieveMaintenanceToken(with: mockURL,
-                                              authorizationServerId: nil,
                                               oidcClientId: "oidcClientId",
                                               scopes: ["some.scope"],
                                               assertion: "assertion") { result in


### PR DESCRIPTION
### Problem Analysis (Technical)
Remove authorization server id from maintenance token API