### PR TITLE
Fix unconditional update of UV key via patch request

### DIFF
--- a/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
+++ b/Sources/DeviceAuthenticator/Networking/LegacyServerAPI.swift
@@ -159,6 +159,7 @@ class LegacyServerAPI: ServerAPIProtocol {
                                     appSignals: [String: _OktaCodableArbitaryType]?,
                                     enrollingFactors: [EnrollingFactor],
                                     token: OktaRestAPIToken,
+                                    enrollmentContext: EnrollmentContext,
                                     completion: @escaping (_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void) {
         if case .none = token {
             completion(.failure(DeviceAuthenticatorError.internalError("No token provided for update enrollment request")))

--- a/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/ServerAPIProtocol.swift
@@ -70,6 +70,7 @@ protocol ServerAPIProtocol {
                                     appSignals: [String: _OktaCodableArbitaryType]?,
                                     enrollingFactors: [EnrollingFactor],
                                     token: OktaRestAPIToken,
+                                    enrollmentContext: EnrollmentContext,
                                     completion: @escaping (_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void)
 
     func deleteAuthenticatorRequest(enrollment: AuthenticatorEnrollment,

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -295,7 +295,8 @@ class OktaTransactionEnroll: OktaTransaction {
                                                     deviceModel: deviceModel,
                                                     appSignals: self.enrollmentContext.applicationSignals,
                                                     enrollingFactors: factorsMetaData,
-                                                    token: token) { result in
+                                                    token: token,
+                                                    enrollmentContext: self.enrollmentContext) { result in
                 self.handleServerResult(result, andCall: onCompletion)
             }
         }

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -103,7 +103,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
         enrollment.enrolledFactors.append(pushFactor)
         var updateAuthenticatorRequestHookCalled = false
         let pushTokenToCompare = "push_token".data(using: .utf8)!
-        restAPIMock.updateAuthenticatorRequestHook = { url, enrollmentId, metadata, deviceSignalsModel, allSignals, factors, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { url, enrollmentId, metadata, deviceSignalsModel, allSignals, factors, _, context, completion in
             let pushMethod = factors.first(where: { $0.methodType == .push })
             let pushToken = pushMethod?.pushToken
             XCTAssertEqual(pushToken, pushTokenToCompare.hexString())
@@ -257,7 +257,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                                                                                               methods: [.push]))
         try? mockStorageManager.storeAuthenticatorPolicy(policy, orgId: enrollment.orgId)
         var updateAuthenticatorRequestHookCalled = false
-        restAPIMock.updateAuthenticatorRequestHook = { url, data, token, _, _, enrollingFactors, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { url, data, token, _, _, enrollingFactors, _, context, completion in
             guard let enrollingPushFactor = enrollingFactors.first(where: { $0.methodType == .push }) else {
                 completion(.failure(.genericError("")))
                 return

--- a/Tests/DeviceAuthenticatorUnitTests/LegacyServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/LegacyServerAPITests.swift
@@ -129,13 +129,24 @@ final class LegacyServerAPITests: XCTestCase {
                                               isFipsCompliant: nil,
                                               keys: signingKeys,
                                               transactionTypes: .login)
+        let enrollmentContext = EnrollmentContext(accessToken: nil,
+                                                  activationToken: nil,
+                                                  orgHost: URL(string: "tenant.okta.com")!,
+                                                  authenticatorKey: "authenticatorKey",
+                                                  oidcClientId: nil,
+                                                  pushToken: .tokenString("pushToken"),
+                                                  enrollBiometricKey: true,
+                                                  deviceSignals: nil,
+                                                  biometricSettings: nil,
+                                                  transactionTypes: [.login])
         legacyAPI.updateAuthenticatorRequest(orgHost: mockURL,
                                              enrollmentId: "enrollmentId",
                                              metadata: metadata,
                                              deviceModel: deviceSignals,
                                              appSignals: nil,
                                              enrollingFactors: [enrollingFactor],
-                                             token: .accessToken("accessToken")) { result in
+                                             token: .accessToken("accessToken"),
+                                             enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(_):
                 XCTFail("Unexpected failure")
@@ -412,13 +423,24 @@ final class LegacyServerAPITests: XCTestCase {
                                               isFipsCompliant: nil,
                                               keys: signingKeys,
                                               transactionTypes: .login)
+        let enrollmentContext = EnrollmentContext(accessToken: nil,
+                                                  activationToken: nil,
+                                                  orgHost: URL(string: "tenant.okta.com")!,
+                                                  authenticatorKey: "authenticatorKey",
+                                                  oidcClientId: nil,
+                                                  pushToken: .tokenString("pushToken"),
+                                                  enrollBiometricKey: true,
+                                                  deviceSignals: nil,
+                                                  biometricSettings: nil,
+                                                  transactionTypes: [.login])
         legacyAPI.updateAuthenticatorRequest(orgHost: mockURL,
                                              enrollmentId: "enrollmentId",
                                              metadata: metadata,
                                              deviceModel: deviceSignals,
                                              appSignals: nil,
                                              enrollingFactors: [enrollingFactor],
-                                             token: .accessToken("accessToken")) { result in
+                                             token: .accessToken("accessToken"),
+                                             enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -1)
@@ -443,7 +465,8 @@ final class LegacyServerAPITests: XCTestCase {
                                              deviceModel: deviceSignals,
                                              appSignals: nil,
                                              enrollingFactors: [enrollingFactor],
-                                             token: .accessToken("accessToken")) { result in
+                                             token: .accessToken("accessToken"),
+                                             enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -6)
@@ -468,7 +491,8 @@ final class LegacyServerAPITests: XCTestCase {
                                              deviceModel: deviceSignals,
                                              appSignals: nil,
                                              enrollingFactors: [enrollingFactor],
-                                             token: .accessToken("accessToken")) { result in
+                                             token: .accessToken("accessToken"),
+                                             enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -6)

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/RestAPIMock.swift
@@ -21,7 +21,7 @@ import OktaLogger
 class RestAPIMock: ServerAPIProtocol {
     typealias enrollAuthenticatorRequestType = (URL, AuthenticatorMetaDataModel, DeviceSignalsModel, [String : _OktaCodableArbitaryType]?, [EnrollingFactor], OktaRestAPIToken, (_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void) -> Void
     typealias downloadOrgIdType = (URL, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
-    typealias updateAuthenticatorRequestType = (URL, String, AuthenticatorMetaDataModel, DeviceSignalsModel, [String : _OktaCodableArbitaryType]?, [EnrollingFactor], OktaRestAPIToken, @escaping (_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void) -> Void
+    typealias updateAuthenticatorRequestType = (URL, String, AuthenticatorMetaDataModel, DeviceSignalsModel, [String : _OktaCodableArbitaryType]?, [EnrollingFactor], OktaRestAPIToken, EnrollmentContext, @escaping (_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void) -> Void
     typealias downloadAuthenticatorMetadataType = (URL, String, OktaRestAPIToken, (Result<AuthenticatorMetaDataModel, DeviceAuthenticatorError>) -> Void) -> Void
     typealias deleteAuthenticatorRequestType = (AuthenticatorEnrollment, OktaRestAPIToken, (_ result: HTTPURLResult?, _ error: DeviceAuthenticatorError?) -> Void) -> Void
     typealias pendingChallengeRequestType = (URL, OktaRestAPIToken, (HTTPURLResult?, DeviceAuthenticatorError?) -> Void) -> Void
@@ -115,6 +115,7 @@ class RestAPIMock: ServerAPIProtocol {
                                            appSignals: [String: _OktaCodableArbitaryType]?,
                                            enrollingFactors: [EnrollingFactor],
                                            token: OktaRestAPIToken,
+                                           enrollmentContext: EnrollmentContext,
                                            completion: @escaping (Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Void) {
         if let oktaError = error {
             completion(.failure(oktaError))
@@ -122,7 +123,15 @@ class RestAPIMock: ServerAPIProtocol {
         }
 
         if let updateAuthenticatorRequestHook = updateAuthenticatorRequestHook {
-            updateAuthenticatorRequestHook(orgHost, enrollmentId, metadata, deviceModel, appSignals, enrollingFactors, token, completion)
+            updateAuthenticatorRequestHook(orgHost,
+                                           enrollmentId,
+                                           metadata,
+                                           deviceModel,
+                                           appSignals,
+                                           enrollingFactors,
+                                           token,
+                                           enrollmentContext,
+                                           completion)
         } else {
             restAPI.updateAuthenticatorRequest(orgHost: orgHost,
                                                enrollmentId: enrollmentId,
@@ -131,6 +140,7 @@ class RestAPIMock: ServerAPIProtocol {
                                                appSignals: appSignals,
                                                enrollingFactors: enrollingFactors,
                                                token: token,
+                                               enrollmentContext: enrollmentContext,
                                                completion: completion)
         }
     }

--- a/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/MyAccountServerAPITests.swift
@@ -230,13 +230,24 @@ final class MyAccountServerAPITests: XCTestCase {
                                               isFipsCompliant: nil,
                                               keys: signingKeys,
                                               transactionTypes: TransactionType(rawValue: 3))
+        let enrollmentContext = EnrollmentContext(accessToken: nil,
+                                                  activationToken: nil,
+                                                  orgHost: URL(string: "tenant.okta.com")!,
+                                                  authenticatorKey: "authenticatorKey",
+                                                  oidcClientId: nil,
+                                                  pushToken: .tokenString("pushToken"),
+                                                  enrollBiometricKey: true,
+                                                  deviceSignals: nil,
+                                                  biometricSettings: nil,
+                                                  transactionTypes: [.ciba, .login])
         myAccountAPI.updateAuthenticatorRequest(orgHost: mockURL,
                                                 enrollmentId: enrollmentId,
                                                 metadata: metadata,
                                                 deviceModel: deviceSignals,
                                                 appSignals: nil,
                                                 enrollingFactors: [enrollingFactor],
-                                                token: .accessToken("accessToken")) { result in
+                                                token: .accessToken("accessToken"),
+                                                enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(_):
                 XCTFail("Unexpected failure")
@@ -422,13 +433,24 @@ final class MyAccountServerAPITests: XCTestCase {
                                               isFipsCompliant: nil,
                                               keys: signingKeys,
                                               transactionTypes: .login)
+        let enrollmentContext = EnrollmentContext(accessToken: nil,
+                                                  activationToken: nil,
+                                                  orgHost: URL(string: "tenant.okta.com")!,
+                                                  authenticatorKey: "authenticatorKey",
+                                                  oidcClientId: nil,
+                                                  pushToken: .tokenString("pushToken"),
+                                                  enrollBiometricKey: true,
+                                                  deviceSignals: nil,
+                                                  biometricSettings: nil,
+                                                  transactionTypes: [.ciba, .login])
         myAccountAPI.updateAuthenticatorRequest(orgHost: mockURL,
                                                 enrollmentId: "enrollmentId",
                                                 metadata: metadata,
                                                 deviceModel: deviceSignals,
                                                 appSignals: nil,
                                                 enrollingFactors: [enrollingFactor],
-                                                token: .accessToken("accessToken")) { result in
+                                                token: .accessToken("accessToken"),
+                                                enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -1)
@@ -453,7 +475,8 @@ final class MyAccountServerAPITests: XCTestCase {
                                                 deviceModel: deviceSignals,
                                                 appSignals: nil,
                                                 enrollingFactors: [enrollingFactor],
-                                                token: .accessToken("accessToken")) { result in
+                                                token: .accessToken("accessToken"),
+                                                enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -6)
@@ -478,7 +501,8 @@ final class MyAccountServerAPITests: XCTestCase {
                                                 deviceModel: deviceSignals,
                                                 appSignals: nil,
                                                 enrollingFactors: [enrollingFactor],
-                                                token: .accessToken("accessToken")) { result in
+                                                token: .accessToken("accessToken"),
+                                                enrollmentContext: enrollmentContext) { result in
             switch result {
             case .failure(let error):
                 XCTAssertEqual(error.errorCode, -6)

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
@@ -610,7 +610,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
                                                                  cryptoManager: cryptoManager)
 
         let restAPIHookCalled = expectation(description: "Rest API hook expected!")
-        self.restAPIMock.updateAuthenticatorRequestHook = { orgHost, _, _, _, _, _, token, completion in
+        self.restAPIMock.updateAuthenticatorRequestHook = { orgHost, _, _, _, _, _, token, context, completion in
             XCTAssertEqual(orgHost.absoluteString, "tenant.okta.com")
             if case .authenticationToken(_) = token {
                 XCTAssertNotNil(token.token)
@@ -651,7 +651,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
                                                                  userVerificationKeyTag: nil)
 
         let hookCalled = expectation(description: "Rest API hook expected!")
-        self.restAPIMock.updateAuthenticatorRequestHook = { orgHost, _, _, _, _, _, token, completion in
+        self.restAPIMock.updateAuthenticatorRequestHook = { orgHost, _, _, _, _, _, token, context, completion in
             if case .authenticationToken(_) = token {
                 XCTAssertNotNil(token.token)
             } else {
@@ -984,7 +984,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
         }
 
         let updateAuthenticatorCompletionCalled = expectation(description: "Update authenticator expected!")
-        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, _, completion in
             updateAuthenticatorCompletionCalled.fulfill()
             let enrollmentSummary = EnrollmentSummary(enrollmentId: "",
                                                       userId: "",
@@ -1021,7 +1021,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
         restAPIMock.downloadAuthenticatorMetadataHook = { _, _, _, _ in
             XCTFail("Unexpected call")
         }
-        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, _, completion in
             XCTFail("Unexpected call")
         }
 
@@ -1062,7 +1062,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
         }
 
         var updateAuthenticatorCompletionCalled = false
-        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, _, completion in
             updateAuthenticatorCompletionCalled = true
             let enrollmentSummary = EnrollmentSummary(enrollmentId: "",
                                                       userId: "",
@@ -1111,7 +1111,7 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
             XCTFail("Unexpected call")
         }
         let updateAuthenticatorRequestHookCalled = expectation(description: "Update authenticator request expected!")
-        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, completion in
+        restAPIMock.updateAuthenticatorRequestHook = { _, _, _, _, _, _, _, _, completion in
             updateAuthenticatorRequestHookCalled.fulfill()
             let enrollmentSummary = EnrollmentSummary(enrollmentId: "",
                                                       userId: "",


### PR DESCRIPTION
### Problem Analysis (Technical)
UV key is always updated in patch request. That causes `Invalid Token Provided` issue when maintenance token is used

### Solution (Technical)
Use EnrollmentContext parameter to get the transaction settings