### PR TITLE
Return all challenges as array for dictionaries via callback

### DIFF
--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPullChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPullChallenge.swift
@@ -75,12 +75,10 @@ class OktaTransactionPullChallenge: OktaTransaction {
                 }
 
                 var challenges = [PushChallenge]()
-                var unrecognizedChallenges = [[String: Any]]()
                 payload.forEach { challengeDictionary in
                     guard let pushBindJWT = self.parsePushBindJWT(info: challengeDictionary, allowedClockSkewInSeconds: allowedClockSkewInSeconds),
                           let context = pushBindJWT.jwt.payload["challengeContext"] as? [AnyHashable: Any] else {
                         self.logger.warning(eventName: "Pull challenge failed", message: "Failed to parse JWT. Payload is invalid or expired")
-                        unrecognizedChallenges.append(challengeDictionary)
                         return
                     }
 
@@ -98,7 +96,7 @@ class OktaTransactionPullChallenge: OktaTransaction {
                     challenges.append(pushChallenge)
                 }
 
-                completion(challenges, unrecognizedChallenges, nil)
+                completion(challenges, payload, nil)
             }
         }
     }

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPullChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPullChallengeTests.swift
@@ -78,7 +78,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         var completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(pullChallengeTransaction.allowedClockSkewInSeconds, 300)
                 XCTAssertEqual(pushChallenges.count, 1)
                 XCTAssertNil(error)
@@ -103,9 +103,9 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                            logger: OktaLoggerMock())
         completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(pushChallenges.count, 1)
-                XCTAssertEqual(unrecognizedChallenges.count, 1)
+                XCTAssertEqual(allChallenges.count, 2)
                 XCTAssertNil(error)
                 completionExpectation.fulfill()
         }
@@ -140,7 +140,7 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(pullChallengeTransaction.allowedClockSkewInSeconds, 300)
                 XCTAssertEqual(pushChallenges.count, 1)
                 XCTAssertNil(error)
@@ -186,10 +186,10 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         var pullChallengeCallbackCalled = false
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(error?.localizedDescription, "Failed to read update push token url")
                 XCTAssertTrue(pushChallenges.isEmpty)
-                XCTAssertTrue(unrecognizedChallenges.isEmpty)
+                XCTAssertTrue(allChallenges.isEmpty)
                 pullChallengeCallbackCalled = true
         }
         XCTAssertTrue(pullChallengeCallbackCalled)
@@ -222,10 +222,10 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(error?.localizedDescription, "Server call has failed")
                 XCTAssertTrue(pushChallenges.isEmpty)
-                XCTAssertTrue(unrecognizedChallenges.isEmpty)
+                XCTAssertTrue(allChallenges.isEmpty)
                 completionExpectation.fulfill()
         }
         wait(for: [completionExpectation], timeout: 1)
@@ -258,10 +258,10 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertEqual(error?.localizedDescription, "Failed to decode server payload")
                 XCTAssertTrue(pushChallenges.isEmpty)
-                XCTAssertTrue(unrecognizedChallenges.isEmpty)
+                XCTAssertTrue(allChallenges.isEmpty)
                 completionExpectation.fulfill()
         }
         wait(for: [completionExpectation], timeout: 1)
@@ -294,10 +294,10 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertNil(error)
                 XCTAssertTrue(pushChallenges.isEmpty)
-                XCTAssertEqual(unrecognizedChallenges.count, 1)
+                XCTAssertEqual(allChallenges.count, 1)
                 completionExpectation.fulfill()
         }
         wait(for: [completionExpectation], timeout: 1)
@@ -330,10 +330,10 @@ class TransactionPullChallengeTests: XCTestCase {
                                                                                logger: OktaLoggerMock())
         let completionExpectation = expectation(description: "callback should be called")
         pullChallengeTransaction.pullChallenge(
-            allowedClockSkewInSeconds: 300) { pushChallenges, unrecognizedChallenges, error in
+            allowedClockSkewInSeconds: 300) { pushChallenges, allChallenges, error in
                 XCTAssertNil(error)
                 XCTAssertTrue(pushChallenges.isEmpty)
-                XCTAssertEqual(unrecognizedChallenges.count, 1)
+                XCTAssertEqual(allChallenges.count, 1)
                 completionExpectation.fulfill()
         }
         wait(for: [completionExpectation], timeout: 1)


### PR DESCRIPTION
### Problem Analysis (Technical)
Expose additional parameter in pending challenge callback to return all received challenges