### PR TITLE
Enable bioOrPin key for authentications and enrollment deletion

### DIFF
--- a/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaBindJWT.swift
@@ -49,6 +49,7 @@ class OktaBindJWT {
         case unknown
         case proofOfPossession
         case userVerification
+        case userVerificationBioOrPin
     }
 
     enum MethodType: String, RawRepresentable {

--- a/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
@@ -392,9 +392,12 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
                 return
             }
 
-            if preferUVKey,
-               let userVerificationKeyTag = self.findUVKeyTagFromEnrolledFactors() {
-                keyTagToUse = userVerificationKeyTag
+            if preferUVKey {
+                if let userVerificationBioOrPinKeyTag = self.findUVBioOrPinKeyTagFromEnrolledFactors() {
+                    keyTagToUse = userVerificationBioOrPinKeyTag
+                } else if let userVerificationKeyTag = self.findUVKeyTagFromEnrolledFactors() {
+                    keyTagToUse = userVerificationKeyTag
+                }
             }
 
             guard let key = self.cryptoManager.get(keyOf: .privateKey, with: keyTagToUse, context: LAContext()) else {
@@ -429,6 +432,10 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
 
     func findUVKeyTagFromEnrolledFactors() -> String? {
         return self.enrolledFactors.first(where: { $0.userVerificationKeyTag != nil })?.userVerificationKeyTag
+    }
+
+    func findUVBioOrPinKeyTagFromEnrolledFactors() -> String? {
+        return self.enrolledFactors.first(where: { $0.userVerificationBioOrPinKeyTag != nil })?.userVerificationBioOrPinKeyTag
     }
 }
 

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -18,20 +18,6 @@ import LoggerCore
 import OktaLogger
 #endif
 
-enum UserVerificationKeyType {
-    case biometrics
-    case biometricsOrPin
-
-    var jwtKeyType: OktaBindJWT.KeyType {
-        switch self {
-        case .biometrics:
-            return .userVerification
-        case .biometricsOrPin:
-            return .userVerificationBioOrPin
-        }
-    }
-}
-
 class OktaTransactionPossessionChallengeBase: OktaTransaction {
     enum AuthenticationMethodReference: String {
         case fingerPrint = "fpt"
@@ -136,7 +122,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
 
     /// Try to read UV key. Ask for UV prompt customization settings via `onIdentityStep` closure
     func tryReadUserVerificationKey(with keyTag: String,
-                                    keyType: UserVerificationKeyType,
+                                    keyType: OktaBindJWT.KeyType,
                                     userVerificationType: UserVerificationChallengeRequirement? = nil,
                                     enrollment: AuthenticatorEnrollment,
                                     onIdentityStep: @escaping (RemediationStep) -> Void,
@@ -382,7 +368,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                 return
             }
             tryReadUserVerificationKey(with: userVerificationKeyTag,
-                                       keyType: .biometrics,
+                                       keyType: .userVerification,
                                        userVerificationType: userVerificationType,
                                        enrollment: enrollment,
                                        onIdentityStep: onIdentityStep,
@@ -396,7 +382,7 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                 return
             }
             tryReadUserVerificationKey(with: userVerificationBioOrPinKeyTag,
-                                       keyType: .biometricsOrPin,
+                                       keyType: .userVerificationBioOrPin,
                                        userVerificationType: userVerificationType,
                                        enrollment: enrollment,
                                        onIdentityStep: onIdentityStep,

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -318,13 +318,8 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     messageReason = .userVerificationFailed
                 }
             }
-            // Surface the error via the non-blocking 'message' identity step
-            self.postMessageToApplication(message: "Failed to sign with key \(skippedKey), falling back to \(keyTypes.description)",
-                                          reason: messageReason,
-                                          error: error,
-                                          transactionContext: transactionContext)
 
-            // Update consent value for cases where appropriate for error
+            // Update consent value and next keys for cases where appropriate for error
             if skippedKey == .userVerification || skippedKey == .userVerificationBioOrPin {
                 if messageReason == .userVerificationCancelledByUser {
                     transactionContext.userConsentResponseValue = .cancelledUserVerification
@@ -349,6 +344,13 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     }
                 }
             }
+
+            // Surface the error via the non-blocking 'message' identity step
+            self.postMessageToApplication(message: "Failed to sign with key \(skippedKey), falling back to \(keyTypes.description)",
+                                          reason: messageReason,
+                                          error: error,
+                                          transactionContext: transactionContext)
+
             self.signJWTAndSendRequest(transactionContext: transactionContext,
                                        keysRequirements: keyTypes)
         } else {

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPushChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPushChallenge.swift
@@ -59,7 +59,7 @@ class OktaTransactionPushChallenge: OktaTransactionPossessionChallengeBase {
         if pushChallenge.userResponse != .userApproved {
             transactionContext.userConsentResponseValue = .denied
         }
-        if keyType == .userVerification && pushChallenge.userResponse == .userApproved {
+        if (keyType == .userVerification || keyType == .userVerificationBioOrPin) && pushChallenge.userResponse == .userApproved {
             transactionContext.userConsentResponseValue = .approvedUserVerification
         } else {
             // Use PoP key for the deny case
@@ -147,6 +147,7 @@ class OktaTransactionPushChallenge: OktaTransactionPossessionChallengeBase {
     }
 
     override func tryReadUserVerificationKey(with keyTag: String,
+                                             keyType: UserVerificationKeyType,
                                              userVerificationType: UserVerificationChallengeRequirement? = nil,
                                              enrollment: AuthenticatorEnrollment,
                                              onIdentityStep: @escaping (RemediationStep) -> Void,
@@ -162,7 +163,7 @@ class OktaTransactionPushChallenge: OktaTransactionPossessionChallengeBase {
         onCompletion(KeyData(keyTag: keyTag,
                              key: jwsKey,
                              amr: [amr],
-                             keyType: .userVerification),
+                             keyType: keyType.jwtKeyType),
                      nil)
     }
 
@@ -202,6 +203,20 @@ class OktaTransactionPushChallenge: OktaTransactionPossessionChallengeBase {
 
         if let pushFactor = enrollment.pushFactor {
             return pushFactor.factorData.userVerificationKeyTag
+        } else {
+            logger.error(eventName: self.logEventName, message: "Can't find push factor in enrollment object")
+            return nil
+        }
+    }
+
+    override func getUserVerificationBioOrPinKeyTag(methodType: OktaBindJWT.MethodType, enrollment: AuthenticatorEnrollment) -> String? {
+        guard methodType == .push else {
+            logger.error(eventName: self.logEventName, message: "Unexpected factor - \(methodType.rawValue)")
+            return nil
+        }
+
+        if let pushFactor = enrollment.pushFactor {
+            return pushFactor.factorData.userVerificationBioOrPinKeyTag
         } else {
             logger.error(eventName: self.logEventName, message: "Can't find push factor in enrollment object")
             return nil

--- a/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
@@ -201,14 +201,39 @@ class OktaTransactionPushChallengeTests: XCTestCase {
         context.enrollment = (pushChallenge.enrollment as! AuthenticatorEnrollment)
 
         var tryReadSigningKeyHookCalled = false
-        transaction.tryReadSigningKeyHook = { _, _, userVerificationType, _, _ in
+        var tryReadSigningKeyHookKeyType: OktaBindJWT.KeyType = .unknown
+        transaction.tryReadSigningKeyHook = { keyType, _, _, _, _ in
             tryReadSigningKeyHookCalled = true
+            tryReadSigningKeyHookKeyType = keyType
         }
 
         transaction.signJWTAndSendRequest(transactionContext: context, keysRequirements: [.userVerification])
 
         XCTAssertTrue(context.userConsentResponseValue == .approvedUserVerification)
         XCTAssertTrue(tryReadSigningKeyHookCalled)
+        XCTAssertEqual(tryReadSigningKeyHookKeyType, .userVerification)
+    }
+
+    func testSignJWTAndSendRequest_UserVerificationBioOrPinKey_UserAccepted() {
+        pushChallenge.userResponse = .userApproved
+        let context = OktaTransaction.TransactionContext(challengeRequest: transaction.challengeRequestJWT) { step in
+            XCTFail("Unexpected call")
+        } appCompletionClosure: { (_, _, _) in
+        }
+        context.enrollment = (pushChallenge.enrollment as! AuthenticatorEnrollment)
+
+        var tryReadSigningKeyHookCalled = false
+        var tryReadSigningKeyHookKeyType: OktaBindJWT.KeyType = .unknown
+        transaction.tryReadSigningKeyHook = { keyType, _, _, _, _ in
+            tryReadSigningKeyHookCalled = true
+            tryReadSigningKeyHookKeyType = keyType
+        }
+
+        transaction.signJWTAndSendRequest(transactionContext: context, keysRequirements: [.userVerificationBioOrPin])
+
+        XCTAssertTrue(context.userConsentResponseValue == .approvedUserVerification)
+        XCTAssertTrue(tryReadSigningKeyHookCalled)
+        XCTAssertEqual(tryReadSigningKeyHookKeyType, .userVerificationBioOrPin)
     }
 
     func testSignJWTAndSendRequest_UserVerificationKey_UserDenied() {
@@ -220,14 +245,17 @@ class OktaTransactionPushChallengeTests: XCTestCase {
         context.enrollment = (pushChallenge.enrollment as! AuthenticatorEnrollment)
 
         var tryReadSigningKeyHookCalled = false
-        transaction.tryReadSigningKeyHook = { _, _, userVerificationType, _, _ in
+        var tryReadSigningKeyHookKeyType: OktaBindJWT.KeyType = .unknown
+        transaction.tryReadSigningKeyHook = { keyType, _, _, _, _ in
             tryReadSigningKeyHookCalled = true
+            tryReadSigningKeyHookKeyType = keyType
         }
 
         transaction.signJWTAndSendRequest(transactionContext: context, keysRequirements: [.userVerification])
 
         XCTAssertTrue(context.userConsentResponseValue == .denied)
         XCTAssertTrue(tryReadSigningKeyHookCalled)
+        XCTAssertEqual(tryReadSigningKeyHookKeyType, .proofOfPossession)
     }
 
     func testSignJWTAndSendRequest_ProofOfPossessionKey() {
@@ -289,10 +317,46 @@ class OktaTransactionPushChallengeTests: XCTestCase {
         authContextMock.passcode = true
 
         transaction.localAuthenticationContext = authContextMock
-        transaction.tryReadUserVerificationKey(with: enrollment.pushFactor!.factorData.userVerificationKeyTag!, enrollment: enrollment, onIdentityStep: { identityStep in
+        transaction.tryReadUserVerificationKey(with: enrollment.pushFactor!.factorData.userVerificationKeyTag!, keyType: .biometrics, enrollment: enrollment, onIdentityStep: { identityStep in
             XCTFail("Unexpected closure call")
         }) { keyData, error in
             XCTAssertEqual(keyData?.keyTag, "userVerificationKeyTag")
+            XCTAssertEqual(keyData?.keyType, .userVerification)
+            XCTAssertNotNil(keyData?.key)
+            XCTAssertNil(error)
+            completionExpectation.fulfill()
+        }
+
+        wait(for: [completionExpectation], timeout: 3.0)
+    }
+
+    func testTryReadUserVerificationBioOrPinKey() throws {
+
+        let userVerificationBioOrPinKeyTag = "userVerificationBioOrPinKeyTag"
+        let _ = try? cryptoManager.generate(keyPairWith: .ES256,
+                                            with: userVerificationBioOrPinKeyTag,
+                                            useSecureEnclave: false,
+                                            useBiometrics: false,
+                                            biometricSettings: nil)
+        let transaction = try OktaTransactionPushChallengePartialMock(pushChallenge: pushChallenge,
+                                                                      applicationConfig: applicationConfig,
+                                                                      storageManager: storageMock,
+                                                                      cryptoManager: cryptoManager,
+                                                                      signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                      restAPI: restAPIMock,
+                                                                      logger: OktaLoggerMock())
+
+        let completionExpectation = expectation(description: "Completion has been called!")
+
+        let authContextMock = LAContextMock()
+        authContextMock.passcode = true
+
+        transaction.localAuthenticationContext = authContextMock
+        transaction.tryReadUserVerificationKey(with: enrollment.pushFactor!.factorData.userVerificationBioOrPinKeyTag!, keyType: .biometricsOrPin, enrollment: enrollment, onIdentityStep: { identityStep in
+            XCTFail("Unexpected closure call")
+        }) { keyData, error in
+            XCTAssertEqual(keyData?.keyTag, userVerificationBioOrPinKeyTag)
+            XCTAssertEqual(keyData?.keyType, .userVerificationBioOrPin)
             XCTAssertNotNil(keyData?.key)
             XCTAssertNil(error)
             completionExpectation.fulfill()

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
@@ -246,8 +246,13 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
         }
     }
 
-    func testReadSigningKeyErrorHandler() throws {
-        var mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+    func testUserVerificationKeyType() {
+        XCTAssertEqual(UserVerificationKeyType.biometrics.jwtKeyType, .userVerification)
+        XCTAssertEqual(UserVerificationKeyType.biometricsOrPin.jwtKeyType, .userVerificationBioOrPin)
+    }
+
+    func testReadSigningKeyErrorHandler_userVerificationPermanentlyUnavailable() throws {
+        let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
                                                                         challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
                                                                         stateHandle: "state_handle",
                                                                         httpHeaders: nil,
@@ -257,7 +262,7 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                                                         signalsManager: SignalsManager(logger: OktaLoggerMock()),
                                                                         restAPI: restAPIMock,
                                                                         logger: OktaLoggerMock())
-        var transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+        let transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
                                                                                            appIdentityStepClosure: { step in
         },
                                                                                            appCompletionClosure: { jwt, error, enrollment in
@@ -279,24 +284,27 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                        keysRequirements: [.userVerification, .proofOfPossession])
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
+    }
 
-        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+    func testReadSigningKeyErrorHandler_userVerificationTemporarilyUnavailable() throws {
+        let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                        challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                        stateHandle: "state_handle",
+                                                                        httpHeaders: nil,
+                                                                        loginHint: nil,
+                                                                        storageManager: storageMock,
+                                                                        cryptoManager: cryptoManager,
+                                                                        signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                        restAPI: restAPIMock,
+                                                                        logger: OktaLoggerMock())
+        let transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
                                                                                            appIdentityStepClosure: { step in
         },
                                                                                            appCompletionClosure: { jwt, error, enrollment in
         })
-        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
-                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
-                                                                    stateHandle: "state_handle",
-                                                                    httpHeaders: nil,
-                                                                    loginHint: nil,
-                                                                    storageManager: storageMock,
-                                                                    cryptoManager: cryptoManager,
-                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
-                                                                    restAPI: restAPIMock,
-                                                                    logger: OktaLoggerMock())
-        signJWTAndSendRequestHookCalled = false
-        postMessageToApplicationHookCalled = false
+
+        var signJWTAndSendRequestHookCalled = false
+        var postMessageToApplicationHookCalled = false
         mut.postMessageToApplicationHook = { message, reasonType, error, context in
             XCTAssertEqual(message, "Failed to sign with key userVerification, falling back to proofOfPossession")
             XCTAssertEqual(reasonType, .userVerificationFailed)
@@ -311,24 +319,27 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                        keysRequirements: [.userVerification, .proofOfPossession])
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
+    }
 
-        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+    func testReadSigningKeyErrorHandler_userVerificationCancelledByUser() throws {
+        let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                        challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                        stateHandle: "state_handle",
+                                                                        httpHeaders: nil,
+                                                                        loginHint: nil,
+                                                                        storageManager: storageMock,
+                                                                        cryptoManager: cryptoManager,
+                                                                        signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                        restAPI: restAPIMock,
+                                                                        logger: OktaLoggerMock())
+        let transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
                                                                                            appIdentityStepClosure: { step in
         },
                                                                                            appCompletionClosure: { jwt, error, enrollment in
         })
-        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
-                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
-                                                                    stateHandle: "state_handle",
-                                                                    httpHeaders: nil,
-                                                                    loginHint: nil,
-                                                                    storageManager: storageMock,
-                                                                    cryptoManager: cryptoManager,
-                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
-                                                                    restAPI: restAPIMock,
-                                                                    logger: OktaLoggerMock())
-        signJWTAndSendRequestHookCalled = false
-        postMessageToApplicationHookCalled = false
+
+        var signJWTAndSendRequestHookCalled = false
+        var postMessageToApplicationHookCalled = false
         mut.postMessageToApplicationHook = { message, reasonType, error, context in
             XCTAssertEqual(message, "Failed to sign with key userVerification, falling back to proofOfPossession")
             XCTAssertEqual(reasonType, .userVerificationCancelledByUser)
@@ -343,24 +354,27 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                        keysRequirements: [.userVerification, .proofOfPossession])
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
+    }
 
-        transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
+    func testReadSigningKeyErrorHandler_userVerificationKeyNotEnrolled() throws {
+        let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
+                                                                        challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
+                                                                        stateHandle: "state_handle",
+                                                                        httpHeaders: nil,
+                                                                        loginHint: nil,
+                                                                        storageManager: storageMock,
+                                                                        cryptoManager: cryptoManager,
+                                                                        signalsManager: SignalsManager(logger: OktaLoggerMock()),
+                                                                        restAPI: restAPIMock,
+                                                                        logger: OktaLoggerMock())
+        let transactionContext = OktaTransactionPossessionChallengeBase.TransactionContext(challengeRequest: mut.challengeRequestJWT,
                                                                                            appIdentityStepClosure: { step in
         },
                                                                                            appCompletionClosure: { jwt, error, enrollment in
         })
-        mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
-                                                                    challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),
-                                                                    stateHandle: "state_handle",
-                                                                    httpHeaders: nil,
-                                                                    loginHint: nil,
-                                                                    storageManager: storageMock,
-                                                                    cryptoManager: cryptoManager,
-                                                                    signalsManager: SignalsManager(logger: OktaLoggerMock()),
-                                                                    restAPI: restAPIMock,
-                                                                    logger: OktaLoggerMock())
-        signJWTAndSendRequestHookCalled = false
-        postMessageToApplicationHookCalled = false
+
+        var signJWTAndSendRequestHookCalled = false
+        var postMessageToApplicationHookCalled = false
         mut.postMessageToApplicationHook = { message, reasonType, error, context in
             XCTAssertEqual(message, "Failed to sign with key userVerification, falling back to proofOfPossession")
             XCTAssertEqual(reasonType, .userVerificationKeyNotEnrolled)
@@ -429,6 +443,10 @@ fileprivate class OktaTransactionPossessionChallengeBasePartialMock: OktaTransac
 
     override func getUserVerificationKeyTag(methodType: OktaBindJWT.MethodType, enrollment: AuthenticatorEnrollment) -> String? {
         return enrollment.enrolledFactors.first { $0.userVerificationKeyTag != nil }.map({ $0.userVerificationKeyTag! })
+    }
+
+    override func getUserVerificationBioOrPinKeyTag(methodType: OktaBindJWT.MethodType, enrollment: AuthenticatorEnrollment) -> String? {
+        return enrollment.enrolledFactors.first { $0.userVerificationBioOrPinKeyTag != nil }.map({ $0.userVerificationBioOrPinKeyTag! })
     }
 
     override func getFactorIdFromEnrollment(_ enrollment: AuthenticatorEnrollment) -> String? {

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
@@ -246,11 +246,6 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
         }
     }
 
-    func testUserVerificationKeyType() {
-        XCTAssertEqual(UserVerificationKeyType.biometrics.jwtKeyType, .userVerification)
-        XCTAssertEqual(UserVerificationKeyType.biometricsOrPin.jwtKeyType, .userVerificationBioOrPin)
-    }
-
     func testReadSigningKeyErrorHandler_userVerificationPermanentlyUnavailable() throws {
         let mut = try OktaTransactionPossessionChallengeBasePartialMock(applicationConfig: applicationConfig,
                                                                         challengeRequest: OktaJWTTestData.validDeviceChallengeRequestJWTWithUserMediationRequired(),


### PR DESCRIPTION
### Problem Analysis (Technical)

Use bioOrPin key on ChallengeRequest handling and for enrollment deletion for end-to-end user experience using the passcode-capable key.