### PR TITLE
Support SQLite encryption for macOS Desktop MFA

### DIFF
--- a/Sources/DeviceAuthenticator/Storage/OktaSecureStorage.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaSecureStorage.swift
@@ -12,7 +12,16 @@
 import Foundation
 import LocalAuthentication
 
-class OktaSecureStorage {
+public protocol OktaSecureStorageProtocol {
+    func getData(key: String, biometricPrompt prompt: String?, accessGroup: String?) throws -> Data
+    func set(data: Data,
+             forKey key: String,
+             behindBiometrics: Bool,
+             accessGroup: String?,
+             accessibility: CFString?) throws
+}
+
+class OktaSecureStorage: OktaSecureStorageProtocol {
 
     static let keychainErrorDomain = "com.okta.securestorage"
 


### PR DESCRIPTION
### Problem Analysis (Technical)
OktaSQLiteEncryptionManager has the following issues:
1. Requires OktaSecureStorage to be used. But OktaSecureStorage uses data protection keychain and hence in contexts where data protection keychain cannot be used, OktaSQLiteEncryptionManager cannot be used.
2. Requires keychain group id. But that is not applicable for macOS apps that don't use data protection keychain.
3. Defaults accessibility of the keychain item that holds encryption key to `kSecAttrAccessibleAfterFirstUnlock`. This can be ignored in a custom keychain helper classes but nevertheless forces a requirement that prevents access in pre-login contexts. 

### Solution (Technical)
1. Make the requirement for OktaSecureStorage a protocol requirement that OktaSecureStorage and other keychain helpers can conform to.
2. Make keychain group id optional
3. Make accessibility of keychain item optional