### PR TITLE
OKTA-610195 - Device SDK: Don't send AppInstanceID in UDID device property

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceSignals/DeviceSignals.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/DeviceSignals.swift
@@ -18,6 +18,8 @@ struct DeviceSignals {
     let displayName: String
     /// Unique device identifier
     var udid: String?
+    /// Device serial number
+    var serialNumber: String?
     /// Dictionary with additional application/device signals
     var deviceAttestation: [String: _OktaCodableArbitaryType]?
 

--- a/Sources/DeviceAuthenticator/DeviceSignals/iOS/OktaUnmangedDeviceSignals.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/iOS/OktaUnmangedDeviceSignals.swift
@@ -50,8 +50,7 @@ class OktaUnmanagedDeviceSignals {
         }
 
         if requestedSignals.contains(.udid) {
-            let udid: String? = customDeviceSignals?.udid
-            deviceSignals.udid = udid ?? UIDevice.current.identifierForVendor?.uuidString
+            deviceSignals.udid = customDeviceSignals?.udid
         }
 
         if requestedSignals.contains(.secureHardwarePresent) {
@@ -69,6 +68,10 @@ class OktaUnmanagedDeviceSignals {
 
         if requestedSignals.contains(.screenLockType) {
             deviceSignals.screenLockType = screenLockType
+        }
+
+        if requestedSignals.contains(.serialNumber) {
+            deviceSignals.serialNumber = customDeviceSignals?.serialNumber
         }
 
         return deviceSignals

--- a/Tests/DeviceAuthenticatorUnitTests/OktaUnmanagedDeviceSignalsTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaUnmanagedDeviceSignalsTests.swift
@@ -133,7 +133,7 @@ class OktaUnmanagedDeviceSignalsTests: XCTestCase {
         #endif
         XCTAssertEqual("test device", deviceSignalModel.displayName)
         XCTAssertEqual(ScreenLockValue.biometric, deviceSignalModel.screenLockType)
-        XCTAssertNotNil(deviceSignalModel.udid)
+        XCTAssertNil(deviceSignalModel.udid)
         XCTAssertNil(deviceSignalModel.sid)
         XCTAssertNil(deviceSignalModel.imei)
         XCTAssertNil(deviceSignalModel.meid)


### PR DESCRIPTION
### Problem Analysis (Technical)
SDK should send signal values that are provided by the app without any fallback logic to default signals. One of the example is UDID property which SDK override with default value `UIDevice.current.identifierForVendor?.uuidString`

### Solution (Technical)
Don't override UDID property with default value, send value as-is
