### PR TITLE
OKTA-611592 - Device SDK: Add version downgrade support fro sqlite db

### DIFF
--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
@@ -45,8 +45,8 @@ class OktaSharedSQLite: OktaSharedSQLiteProtocol {
         self.logger = logger
     }
 
-    // MARK: Versioning and Migraiton
-    public static let targetVersion = SQLiteStorageVersion.latestVersion
+    // MARK: Versioning and Migration
+    public internal(set) static var targetVersion = SQLiteStorageVersion.latestVersion
     public var lastKnownVersion: Version {
         if !sqlitePersistentStorage.sqliteFileExist() {
             // if there is no SQLite stored yet, return Self.targetVersion right away to avoid

--- a/Sources/DeviceAuthenticator/StorageVersioning/OktaStorageMigrator.swift
+++ b/Sources/DeviceAuthenticator/StorageVersioning/OktaStorageMigrator.swift
@@ -30,9 +30,8 @@ class OktaStorageMigrator {
         let storageTargetVersion = type.targetVersion
 
         guard storageTargetVersion >= storageLastKnownVersion else {
-            let error = DeviceAuthenticatorError.storageError(.storageMigrationError("Storage is not backward compatible! Current version: \(storageTargetVersion), last known version: \(storageLastKnownVersion) for \(type)"))
-            logger.error(eventName: "Migration Error", message: "\(error)")
-            throw error
+            logger.warning(eventName: "Migration", message: "DB downgrade detected, current version: \(storageLastKnownVersion.rawValue), target version: \(storageTargetVersion.rawValue)")
+            return false
         }
 
         guard storageTargetVersion != storageLastKnownVersion else {


### PR DESCRIPTION
### Problem Analysis (Technical)
SDK fires exception when detects db version downgrade

### Solution (Technical)
Remove panic code from SQLite migration area where SDK rejects to initialize if db downgrade case has been detected
Device SDK will make the best effort to continue to work with existing version of db

### Affected Components
OktaSharedSQLite.swift
