### PR TITLE
Store server error code via a separate storage API

### DIFF
--- a/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/AuthenticatorEnrollment.swift
@@ -193,7 +193,7 @@ class AuthenticatorEnrollment: AuthenticatorEnrollmentProtocol {
         } else if let errorCode = error?.serverErrorCode {
             recordError(errorCode)
         }
-        try? self.storageManager.storeEnrollment(self)
+        try? self.storageManager.storeServerErrorCode(self.serverError, enrollment: self)
     }
 
     var userVerificationEnabled: Bool {

--- a/Sources/DeviceAuthenticator/Storage/OktaEnrollmentStorageProtocol.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaEnrollmentStorageProtocol.swift
@@ -19,6 +19,7 @@ protocol OktaEnrollmentStorageProtocol {
     func allEnrollments() -> [AuthenticatorEnrollmentProtocol]
     func enrollmentById(enrollmentId: String) -> AuthenticatorEnrollmentProtocol?
     func enrollmentsByOrgId(_ orgId: String) -> [AuthenticatorEnrollmentProtocol]
+    func storeServerErrorCode(_ errorCode: ServerErrorCode?, enrollment: AuthenticatorEnrollmentProtocol) throws
 
     var enrollmentsCount: Int? { get }
 }

--- a/Sources/DeviceAuthenticator/Storage/OktaStorageManager.swift
+++ b/Sources/DeviceAuthenticator/Storage/OktaStorageManager.swift
@@ -121,6 +121,10 @@ extension OktaStorageManager: OktaEnrollmentStorageProtocol {
         return storage.enrollmentsByOrgId(orgId)
     }
 
+    public func storeServerErrorCode(_ errorCode: ServerErrorCode?, enrollment: AuthenticatorEnrollmentProtocol) throws {
+        return try storage.storeServerErrorCode(errorCode, enrollment: enrollment)
+    }
+
     var enrollmentsCount: Int? {
         return storage.enrollmentsCount
     }

--- a/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
+++ b/Sources/DeviceAuthenticator/Storage/SQLite/OktaSharedSQLite.swift
@@ -124,6 +124,18 @@ class OktaSharedSQLite: OktaSharedSQLiteProtocol {
         }
     }
 
+    func storeServerErrorCode(_ errorCode: ServerErrorCode?, enrollment: AuthenticatorEnrollmentProtocol) throws {
+        do {
+            try pool?.write({ db in
+                try db.execute(
+                    sql: "UPDATE Enrollment SET serverErrorCode = :serverErrorCode WHERE enrollmentId = :enrollmentId AND orgId = :orgId",
+                    arguments: [errorCode?.rawValue, enrollment.enrollmentId, enrollment.organization.id])
+            })
+        } catch {
+            throw DeviceAuthenticatorError.storageError(StorageError.sqliteError(error.localizedDescription))
+        }
+    }
+
     var factorStatement: String {
         return "INSERT INTO EnrolledMethod (id, enrollmentId, orgId, type, proofOfPossessionKeyTag, userVerificationKeyTag, userVerificationBioOrPinKeyTag, links, passCodeLength, timeIntervalSec, algorithm, sharedSecret, transactionTypes, createdTimestamp, updatedTimestamp) VALUES (:id, :enrollmentId, :enrollmentOrgId, :type, :proofOfPossessionKeyTag, :userVerificationKeyTag, :userVerificationBioOrPinKeyTag, :links, :passCodeLength, :timeIntervalSec, :algorithm, :sharedSecret, :transactionTypes, :createdTimestamp, :updatedTimestamp) ON CONFLICT(id,enrollmentId,orgId) DO UPDATE SET id = :id, enrollmentId = :enrollmentId, orgId = :enrollmentOrgId, type = :type, proofOfPossessionKeyTag = :proofOfPossessionKeyTag, userVerificationKeyTag = :userVerificationKeyTag, userVerificationBioOrPinKeyTag = :userVerificationBioOrPinKeyTag, links = :links, passCodeLength = :passCodeLength, timeIntervalSec = :timeIntervalSec, algorithm = :algorithm, sharedSecret = :sharedSecret, transactionTypes = :transactionTypes, updatedTimestamp = :updatedTimestamp"
     }

--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/StorageManagerMock.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/StorageManagerMock.swift
@@ -115,4 +115,10 @@ class StorageMock: PersistentStorageProtocol {
     func deleteAuthenticatorPolicyForOrgId(_ orgId: String) throws {
         policies.removeValue(forKey: orgId)
     }
+
+    func storeServerErrorCode(_ errorCode: ServerErrorCode?, enrollment: AuthenticatorEnrollmentProtocol) throws {
+        let enrollmentObject = enrollment as! AuthenticatorEnrollment
+        enrollmentObject.serverError = errorCode
+        try self.storeEnrollment(enrollmentObject)
+    }
 }

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
@@ -731,6 +731,20 @@ class OktaSharedSQLiteTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    func testStoreServerErrorCode() throws {
+        let sqlite = try createSqlite(fullDatabaseEncryption: false, prefersSecureEnclaveUsage: false, schemaVersion: .v2)
+        let enrollment = entitiesGenerator.createAuthenticator(methodTypes: [AuthenticatorMethod.push], transactionTypes: [.login])
+        try sqlite.storeEnrollment(enrollment)
+
+        try sqlite.storeServerErrorCode(.deviceDeleted, enrollment: enrollment)
+        var enrollmentToVerify = sqlite.enrollmentById(enrollmentId: enrollment.enrollmentId) as! AuthenticatorEnrollment
+        XCTAssertEqual(enrollmentToVerify.serverError, ServerErrorCode.deviceDeleted)
+
+        try sqlite.storeServerErrorCode(nil, enrollment: enrollment)
+        enrollmentToVerify = sqlite.enrollmentById(enrollmentId: enrollment.enrollmentId) as! AuthenticatorEnrollment
+        XCTAssertNil(enrollmentToVerify.serverError)
+    }
+
     // MARK: Private Helpers
 
     private func createStorage(prefersSecureEnclaveUsage: Bool, schemaVersion: SQLiteStorageVersion = .latestVersion) throws -> OktaSQLitePersistentStorage {


### PR DESCRIPTION
### Problem Analysis (Technical)
We store full enrollment just to update one flag on enrollment level

### Solution (Technical)
Introduce a separate API for storing server error code