### PR TITLE
Send UV_TEMPORARILY_UNAVAILABLE userConsent if device passcode is not…

### DIFF
--- a/Sources/DeviceAuthenticator/SecurityError.swift
+++ b/Sources/DeviceAuthenticator/SecurityError.swift
@@ -24,6 +24,8 @@ public enum SecurityError: Error {
     case keyCorrupted(Error)
     /// Thrown when user cancels local authentication process via local authentication dialog
     case localAuthenticationCancelled(Error)
+    /// Thrown when SDK detect that no passcode set on the device
+    case localAuthenticationPasscodeNotSet(Error)
     /// Thrown when user fails to authenticate via local authentication process
     case localAuthenticationFailed(Error)
     /// Thrown for cases that can't be mapped to specific error domains. For example SDK failed to parse web token information
@@ -51,6 +53,11 @@ public extension SecurityError {
         let userCancelledErrorCode = LAError.Code.userCancel.rawValue // -2
         if nsError.code == userCancelledErrorCode && nsError.domain == LAErrorDomain {
             return localAuthenticationCancelled(nsError)
+        }
+
+        let passcodeNotSetErrorCode = LAError.Code.passcodeNotSet.rawValue // -5
+        if nsError.code == passcodeNotSetErrorCode && nsError.domain == LAErrorDomain {
+            return localAuthenticationPasscodeNotSet(nsError)
         }
 
         let corruptedDataErrorCode = TKError.Code.corruptedData.rawValue // -3

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionPossessionChallenge.swift
@@ -300,6 +300,9 @@ class OktaTransactionPossessionChallengeBase: OktaTransaction {
                     messageReason = .userVerificationKeyCorruptedOrMissing
                 } else if case .localAuthenticationCancelled(_) = encErr {
                     messageReason = .userVerificationCancelledByUser
+                } else if case .localAuthenticationPasscodeNotSet(_) = encErr {
+                    // Biometrics still might be available after re-setting a device passcode
+                    messageReason = .userVerificationFailed
                 } else if case .localAuthenticationFailed(_) = encErr {
                     messageReason = .userVerificationFailed
                 }

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionPossessionChallengeBaseTests.swift
@@ -314,6 +314,12 @@ class TransactionPossessionChallengeBaseTests: XCTestCase {
                                        keysRequirements: [.userVerification, .proofOfPossession])
         XCTAssertTrue(signJWTAndSendRequestHookCalled)
         XCTAssertTrue(postMessageToApplicationHookCalled)
+
+        signJWTAndSendRequestHookCalled = false
+        postMessageToApplicationHookCalled = false
+        mut.readSigningKeyErrorHandler(error: .securityError(.localAuthenticationPasscodeNotSet(NSError())),
+                                       transactionContext: transactionContext,
+                                       keysRequirements: [.userVerification, .proofOfPossession])
     }
 
     func testReadSigningKeyErrorHandler_userVerificationCancelledByUser() throws {


### PR DESCRIPTION
### Problem Analysis (Technical)
Face ID reset leads to invalidation of enrolled `userVerification` key and attempts to sign challenge response JWT return `TKError.Code.corruptedData` error. This error is handled to send `UV_PERMANENTLY_UNAVAILABLE` `userConsent` using PoP key.

If device passcode is turned off, `userVerification` key is not invalidated but all attempts to sign challenge response JWT using this key return `LAError.Code.passcodeNotSet` error which doesn't have a specific handler and treated as general error leading to UC prompting.

### Solution (Technical)

In order to provide the same experience for both cases, added handling of `LAError.Code.passcodeNotSet` error to send `UV_TEMPORARILY_UNAVAILABLE` `userConsent` value. After setting a new passcode the Face ID becomes available again and the `userVerification` key works as before.

