### PR TITLE
Add DeviceId to all enrollment operations

### DIFF
--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -246,10 +246,7 @@ class OktaTransactionEnroll: OktaTransaction {
                             onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
         self.orgId = orgId
         self.metaData = metaData
-        if enrollmentToUpdate != nil {
-            // fetch device enrollment only for update authenticator cases
-            self.deviceEnrollment = try? self.storageManager.deviceEnrollmentByOrgId(orgId)
-        }
+        self.deviceEnrollment = try? self.storageManager.deviceEnrollmentByOrgId(orgId)
         let enrolledFactors: [EnrollingFactor]
         do {
             // Build factors based on metadata requirements


### PR DESCRIPTION
### Problem Analysis (Technical)

At enrollment time, the device id is used to prevent duplicate enrollments from the same device. Previously, the device id was not being sent for new enrollments.

### Solution (Technical)

Adding the device id for all enrollment operations allows the Okta backend to detect and de-duplicate these conflicting enrollments.

