### PR TITLE
OKTA-622047 - Push SDK: Send authenticatorAppKey in Device payload

### DIFF
--- a/Sources/DeviceAuthenticator/ApplicationConfig.swift
+++ b/Sources/DeviceAuthenticator/ApplicationConfig.swift
@@ -41,15 +41,18 @@ public class ApplicationConfig {
     ///   - applicationVersion: Host application version
     ///   - applicationGroupId: AppGroupId entitlement identifier for sharing files and keychain items between applications and extensions
     ///   - keychainGroupId: Optional KeychainSharing entitlement identifier for sharing keychain data. If not provided by your application then sdk falls back to applicationGroupId entitlement for keychain operations
+    ///   - applicationInstallationId: an id that may be used to uniquely identify the device. If not provided SDK will use `UIDevice.current.identifierForVendor` property
     public init(applicationName: String,
                 applicationVersion: String,
                 applicationGroupId: String,
-                keychainGroupId: String? = nil) {
+                keychainGroupId: String? = nil,
+                applicationInstallationId: String? = nil) {
         self.applicationInfo = OktaApplicationInfo(
             applicationName: applicationName,
             applicationVersion: applicationVersion,
             applicationGroupId: applicationGroupId,
-            keychainGroupId: keychainGroupId)
+            keychainGroupId: keychainGroupId,
+            applicationInstallationId: applicationInstallationId)
     }
 
     /// Returns a config value for the specified raw key.

--- a/Sources/DeviceAuthenticator/DeviceAuthenticatorError.swift
+++ b/Sources/DeviceAuthenticator/DeviceAuthenticatorError.swift
@@ -73,7 +73,7 @@ extension DeviceAuthenticatorError: CustomNSError {
             if let errorModel = errorModel {
                 userInfo["json"] = try? JSONEncoder().encode(errorModel)
             } else {
-                userInfo["json"] = [: ]
+                userInfo["json"] = [: ] as [String: Any]
             }
             return userInfo
         case .storageError(error: let error):

--- a/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
@@ -114,6 +114,10 @@ class OktaDeviceModelBuilder {
             deviceModel.clientInstanceDeviceSdkVersion = DeviceAuthenticatorConstants.name + " " + DeviceAuthenticatorConstants.version
         }
 
+        #if os(iOS)
+        deviceModel.authenticatorAppKey = applicationConfig.applicationInfo.applicationInstallationId ?? UIDevice.current.identifierForVendor?.uuidString
+        #endif
+
         return deviceModel
     }
 

--- a/Sources/DeviceAuthenticator/Enrollment/OktaApplicationInfo.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/OktaApplicationInfo.swift
@@ -18,14 +18,17 @@ struct OktaApplicationInfo {
     let applicationVersion: String
     let applicationGroupId: String
     let keychainGroupId: String
+    let applicationInstallationId: String?
 
     init(applicationName: String,
          applicationVersion: String,
          applicationGroupId: String,
-         keychainGroupId: String? = nil) {
+         keychainGroupId: String? = nil,
+         applicationInstallationId: String? = nil) {
         self.applicationName = applicationName
         self.applicationVersion = applicationVersion
         self.applicationGroupId = applicationGroupId
         self.keychainGroupId = keychainGroupId ?? applicationGroupId
+        self.applicationInstallationId = applicationInstallationId
     }
 }

--- a/Sources/DeviceAuthenticator/Networking/DeviceSignalsModel.swift
+++ b/Sources/DeviceAuthenticator/Networking/DeviceSignalsModel.swift
@@ -75,6 +75,7 @@ class DeviceSignalsModel: Codable {
     var clientInstanceBundleId: String?
     var clientInstanceVersion: String?
     var clientInstanceDeviceSdkVersion: String?
+    var authenticatorAppKey: String?
 
     init(platform: PlatformValue?, osVersion: String?, displayName: String?) {
         self.platform = platform

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -37,7 +37,8 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         jwtGenerator = OktaJWTGeneratorMock(logger: OktaLoggerMock())
         applicationConfig = ApplicationConfig(applicationName: "Test App",
                                               applicationVersion: "1.0.0",
-                                              applicationGroupId: ExampleAppConstants.appGroupId)
+                                              applicationGroupId: ExampleAppConstants.appGroupId,
+                                              applicationInstallationId: "applicationInstallationId")
         mockStorageManager = StorageMock()
     }
 
@@ -228,10 +229,12 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         XCTAssertNil(deviceSignalsModel.udid)
         XCTAssertNil(deviceSignalsModel.serialNumber)
         XCTAssertEqual(displayName, deviceSignalsModel.displayName)
+        XCTAssertEqual(deviceSignalsModel.authenticatorAppKey, applicationConfig.applicationInfo.applicationInstallationId)
         #else
         XCTAssertNotNil(deviceSignalsModel.udid)
         XCTAssertNotNil(deviceSignalsModel.serialNumber)
         XCTAssertEqual(displayName, deviceSignalsModel.displayName)
+        XCTAssertNil(deviceSignalsModel.authenticatorAppKey)
         #endif
     }
 }


### PR DESCRIPTION
### Problem Analysis (Technical)
Duplicate enrollments in case of timed-out enrollment requests

### Solution (Technical)
Send `authenticatorAppKey` in signals payload. Signal uniquely identifies the device while application is installed