### PR TITLE
OKTA-646550 - iOS Device SDK: Redo ssws token generation logic to take into account key health

### DIFF
--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -246,7 +246,9 @@ class OktaTransactionEnroll: OktaTransaction {
                             onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
         self.orgId = orgId
         self.metaData = metaData
-        self.deviceEnrollment = try? self.storageManager.deviceEnrollmentByOrgId(orgId)
+        if self.deviceEnrollment == nil {
+            self.deviceEnrollment = try? self.storageManager.deviceEnrollmentByOrgId(orgId)
+        }
         let enrolledFactors: [EnrollingFactor]
         do {
             // Build factors based on metadata requirements

--- a/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/AuthenticatorEnrollmentTests.swift
@@ -446,7 +446,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                 XCTFail("Unexpected success")
             case .failure(let error):
                 if case let .securityError(encryptionError) = error {
-                    XCTAssertEqual(encryptionError, SecurityError.jwtError("Failed to read private key"))
+                    XCTAssertEqual(encryptionError, SecurityError.jwtError("User verification key is not found"))
                 } else {
                     XCTFail("Unexpected error: \(error)")
                 }
@@ -565,7 +565,7 @@ class AuthenticatorEnrollmentTests: XCTestCase {
                 XCTFail("Unexpected success")
             case .failure(let error):
                 if case let .securityError(encryptionError) = error {
-                    XCTAssertEqual(encryptionError, SecurityError.jwtError("Failed to sign jwt"))
+                    XCTAssertEqual(encryptionError, SecurityError.jwtError("User verification key is not found"))
                 } else {
                     XCTFail("Unexpected error: \(error)")
                 }


### PR DESCRIPTION
… all factors and key health

### Problem Analysis (Technical)
Currently logic only checks for tag presence and doesn't check any other factors or keys

### Solution (Technical)
Enumerate all factors and check key health, then use the key for jwt signing
