### PR TITLE
Include device.id and clientInstanceId into update device payload

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - DeviceAuthenticator (1.0.0):
+  - DeviceAuthenticator (1.1.0):
     - GRDB.swift (~> 5)
     - OktaJWT (~> 2.3)
     - OktaLogger/FileLogger (~> 1)
@@ -39,7 +39,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  DeviceAuthenticator: 83de0cf3e4b15d34cc4ad0c629d6c565ca59e0e1
+  DeviceAuthenticator: 21ba9ae8ac3ee8f509e72ee0b18917bf5e1e32d6
   GRDB.swift: e98cd55ec99dea5da99355d588149063e4cfa0eb
   OktaJWT: d9934b947fd0742713557b9ab9e1a313d40751cc
   OktaLogger: 431c11de4d0b819ea4d0b1ac3734f953f5864c32

--- a/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
@@ -82,6 +82,8 @@ class OktaDeviceModelBuilder {
             // Failed to build device key attestation. Recreate the device object on server side and register new client instance key
             _ = cryptoManager.delete(keyPairWith: deviceEnrollment.clientInstanceKeyTag)
             deviceModel = buildForCreateEnrollment(with: deviceEnrollment.clientInstanceKeyTag)
+            deviceModel.id = deviceEnrollment.id
+            deviceModel.clientInstanceId = deviceEnrollment.clientInstanceId
         }
 
         return deviceModel

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -94,8 +94,8 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         // Simulate loss of client instance key
         cryptoManager.privateKey = nil
         deviceSignalsModel = mut.buildForUpdateEnrollment(with: deviceEnrollment)
-        XCTAssertNil(deviceSignalsModel.clientInstanceId)
-        XCTAssertNil(deviceSignalsModel.id)
+        XCTAssertNotNil(deviceSignalsModel.clientInstanceId)
+        XCTAssertNotNil(deviceSignalsModel.id)
         XCTAssertNil(deviceSignalsModel.deviceAttestation)
         validateDeviceSignals(deviceSignalsModel)
     }


### PR DESCRIPTION
### Problem Analysis (Technical)
Server rejects device key reenroll request

### Solution (Technical)
In order to successfully reenroll device key when device key is not available we need to provide deviceModel.id and deviceModel.clientInstanceId in device payload