### PR TITLE
OKTA-643877 - Retry with no deviceId if backend returns .deviceDeleted

### DIFF
--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -287,17 +287,20 @@ class OktaTransactionEnroll: OktaTransaction {
                                                 appSignals: enrollmentContext.applicationSignals,
                                                 enrollingFactors: factorsMetaData,
                                                 token: token) { result in
-            if self.shouldRetryIfDeviceNotFound(result: result) {
-                self.retryEnrollment(factorsMetaData: factorsMetaData, onCompletion: onCompletion)
-            } else {
-                self.handleServerResult(result, andCall: onCompletion)
-            }
+            self.handleServerResult(result, factorsMetaData: factorsMetaData, andCall: onCompletion)
         }
     }
 
     /// For retrying enrollment when E0000153, is returned. This can happen when server deletes the device but client still has the deviceId
-    func retryEnrollment(factorsMetaData: [EnrollingFactor],
-                         onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
+    func retryEnrollmentIfNeeded(error: DeviceAuthenticatorError,
+                                 factorsMetaData: [EnrollingFactor],
+                                 onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
+        guard case .serverAPIError(_, let serverAPIErrorModel) = error,
+              let errorCode = serverAPIErrorModel?.errorCode?.rawValue,
+              ServerErrorCode(raw: errorCode) == .deviceDeleted else {
+            onCompletion(.failure(error))
+            return
+        }
         self.logger.info(eventName: logEventName, message: "Device deleted in backend. Re-enrolling with no deviceId")
         self.deviceEnrollment = nil
         try? self.storageManager.deleteDeviceEnrollmentForOrgId(self.orgId)
@@ -319,7 +322,7 @@ class OktaTransactionEnroll: OktaTransaction {
                                                     enrollingFactors: factorsMetaData,
                                                     token: token,
                                                     enrollmentContext: self.enrollmentContext) { result in
-                self.handleServerResult(result, andCall: onCompletion)
+                self.handleServerResult(result, factorsMetaData: factorsMetaData, andCall: onCompletion)
             }
         }
 
@@ -446,27 +449,18 @@ class OktaTransactionEnroll: OktaTransaction {
     }
 
     func handleServerResult(_ result: Result<EnrollmentSummary, DeviceAuthenticatorError>,
+                            factorsMetaData: [EnrollingFactor],
                             andCall onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
         switch result {
         case .failure(let error):
-            onCompletion(.failure(error))
+            retryEnrollmentIfNeeded(error: error,
+                                    factorsMetaData: factorsMetaData,
+                                    onCompletion: onCompletion)
             return
         case .success(let enrollmentSummary):
             createEnrollmentAndSaveToStorage(enrollmentSummary: enrollmentSummary,
                                              onCompletion: onCompletion)
         }
-    }
-
-    func shouldRetryIfDeviceNotFound(result: Result<EnrollmentSummary, DeviceAuthenticatorError>) -> Bool {
-        guard case .failure(let error) = result else {
-            return false
-        }
-        guard case .serverAPIError(_, let serverAPIErrorModel) = error,
-              let errorCode = serverAPIErrorModel?.errorCode?.rawValue,
-              ServerErrorCode(raw: errorCode) == .deviceDeleted else {
-            return false
-        }
-        return true
     }
 
     func createEnrollmentAndSaveToStorage(enrollmentSummary: EnrollmentSummary,

--- a/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/TransactionEnrollTests.swift
@@ -1346,6 +1346,21 @@ XCTAssertEqual(jwk["okta:kpr"], .string("SOFTWARE"))
         wait(for: [enrollExpectation, metadataDownloadExpectation], timeout: 0.5)
     }
 
+    func testShouldRetryIfDeviceNotFound_WithDeviceNotFoundError_ReturnsTrue() {
+        let urlResponse = HTTPURLResponse(url: URL(string: "tenant.okta.com")!, statusCode: 410, httpVersion: nil, headerFields: nil)!
+        let httpResult = HTTPURLResult(request: URLRequest(url: URL(string: "tenant.okta.com")!),
+                                       response: urlResponse,
+                                       data: nil, error: nil)
+        let serverErrorCode = ServerErrorCode(raw: "E0000153")
+        let serverAPIErrorModel = ServerAPIErrorModel(errorCode: serverErrorCode, errorSummary: nil, errorLink: nil, errorId: nil, status: nil, errorCauses: nil)
+        let result: Result<EnrollmentSummary, DeviceAuthenticatorError> = Result.failure(DeviceAuthenticatorError.serverAPIError(httpResult, serverAPIErrorModel))
+        XCTAssert(transaction.shouldRetryIfDeviceNotFound(result: result))
+    }
+    
+    func testShouldRetryIfDeviceNotFound_WithOtherError_ReturnsFalse() {
+        let result: Result<EnrollmentSummary, DeviceAuthenticatorError> = Result.failure(DeviceAuthenticatorError.genericError(""))
+        XCTAssertFalse(transaction.shouldRetryIfDeviceNotFound(result: result))
+    }
     /*
     func testHandleServerResult_Success() {
         let urlResponse = HTTPURLResponse(url: URL(string: "tenant.okta.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!


### PR DESCRIPTION
### Problem Analysis (Technical)

- Re-enrollment fails when device was deleted by admin.

### Solution (Technical)

- Retry with no deviceEnrollment if backend returns deviceDeleted.
- Verified fix with multiple accounts on the same org.

### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
