### PR TITLE
OKTA-648357 - Conform DeviceSignalsModel to CustomStringConvertible

### DIFF
--- a/Sources/DeviceAuthenticator/Crypto/OktaDeviceBindJWTPayload.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaDeviceBindJWTPayload.swift
@@ -81,7 +81,7 @@ class OktaDeviceBindJWTPayload: OktaJWTPayload, CustomStringConvertible {
 
         // Redact sensitive signals (for logging purposes)
         if var signals = descDict[DeviceBindCodingKeys.deviceSignals.rawValue] as? [String: Any] {
-            let loggableSignals = loggableSignals()
+            let loggableSignals = RequestableSignal.loggableSignals
             for key in signals.keys {
                 if !loggableSignals.contains(key) {
                     signals[key] = "<REDACTED>"
@@ -160,23 +160,6 @@ extension OktaDeviceBindJWTPayload {
             DeviceBindCodingKeys.deviceSignals.rawValue, // individual signals redacted
             DeviceBindCodingKeys.integrations.rawValue,
             DeviceBindCodingKeys.signalProviders.rawValue,
-        ])
-    }
-
-    ///  List of device signals which can be logged (No PII)
-    func loggableSignals() -> Set<String> {
-        Set<String>([
-            RequestableSignal.platform.rawValue,
-            RequestableSignal.manufacturer.rawValue,
-            RequestableSignal.model.rawValue,
-            RequestableSignal.osVersion.rawValue,
-            RequestableSignal.secureHardwarePresent.rawValue,
-            RequestableSignal.diskEncryptionType.rawValue,
-            RequestableSignal.screenLockType.rawValue,
-            RequestableSignal.clientInstanceBundleId.rawValue,
-            RequestableSignal.clientInstanceDeviceSdkVersion.rawValue,
-            RequestableSignal.clientInstanceId.rawValue,
-            RequestableSignal.clientInstanceVersion.rawValue
         ])
     }
 

--- a/Sources/DeviceAuthenticator/Networking/DeviceSignalsModel.swift
+++ b/Sources/DeviceAuthenticator/Networking/DeviceSignalsModel.swift
@@ -43,6 +43,24 @@ enum RequestableSignal: String {
     case clientInstanceDeviceSdkVersion
     case clientInstanceId
     case clientInstanceVersion
+
+    ///  List of device signals which can be logged (No PII)
+    ///  Update DeviceSignalsModel properties if making changes to this list
+    static var loggableSignals: Set<String> {
+        Set<String>([
+            RequestableSignal.platform.rawValue,
+            RequestableSignal.manufacturer.rawValue,
+            RequestableSignal.model.rawValue,
+            RequestableSignal.osVersion.rawValue,
+            RequestableSignal.secureHardwarePresent.rawValue,
+            RequestableSignal.diskEncryptionType.rawValue,
+            RequestableSignal.screenLockType.rawValue,
+            RequestableSignal.clientInstanceBundleId.rawValue,
+            RequestableSignal.clientInstanceDeviceSdkVersion.rawValue,
+            RequestableSignal.clientInstanceId.rawValue,
+            RequestableSignal.clientInstanceVersion.rawValue
+        ])
+    }
 }
 
 struct DeviceSignalsResponseModel: Codable {
@@ -54,7 +72,7 @@ struct DeviceSignalsResponseModel: Codable {
     let clientInstanceId: String
 }
 
-class DeviceSignalsModel: Codable {
+class DeviceSignalsModel: Codable, CustomStringConvertible {
     var platform: PlatformValue?
     var osVersion: String?
     var displayName: String?
@@ -81,6 +99,25 @@ class DeviceSignalsModel: Codable {
         self.platform = platform
         self.osVersion = osVersion
         self.displayName = displayName
+    }
+
+    var description: String {
+        var desc = ""
+        let mirror = Mirror(reflecting: self)
+        let properties = mirror.children
+        for property in properties {
+            guard let label = property.label else {
+                continue
+            }
+            if case Optional<Any>.some(_) = property.value {
+                if RequestableSignal.loggableSignals.contains(label) {
+                    desc = "\(desc), \(label): \(property.value)"
+                } else {
+                    desc = "\(desc), \(label): <REDACTED>"
+                }
+            }
+        }
+        return desc
     }
 }
 


### PR DESCRIPTION
### Problem Analysis (Technical)

Need to log certain 1st party properties and hide others.

### Solution (Technical)

Conform DeviceSignalsModel to CustomStringConvertible so we can customize it's description.

Output after printing object:

`2023-09-18 19:00:35.912621-0400 Okta Verify[1859:843208] {✅ "AsyncSignals": {"message": "First party signals collected: , platform: Optional(OktaDeviceSDK.PlatformValue.iOS), osVersion: Optional("16.6.1"), displayName: <REDACTED>, id: <REDACTED>, manufacturer: Optional("APPLE"), model: Optional("iPhone10,3"), serialNumber: <REDACTED>, udid: <REDACTED>, meid: <REDACTED>, imei: <REDACTED>, sid: <REDACTED>, secureHardwarePresent: Optional(true), screenLockType: Optional(OktaDeviceSDK.ScreenLockValue.biometric), diskEncryptionType: Optional(OktaDeviceSDK.DiskEncryptionValue.full), deviceAttestation: <REDACTED>, clientInstanceId: Optional("FD0C8204-5479-44E6-98B5-EB4187CB1E77"), clientInstanceKey: <REDACTED>, clientInstanceBundleId: Optional("com.okta.mobile.internalrelease"), clientInstanceVersion: Optional("9.3.0"), clientInstanceDeviceSdkVersion: Optional("DeviceAuthenticator 1.1.0"), authenticatorAppKey: <REDACTED>", "defaultProperties": "", "location": "FirstPartySignalsProvider.swift:logSignals(_:):77"}}`


### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
