### PR TITLE
OKTA-652751: Use Data for pulling from file signal

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceSignals/macOS/FileTypeSignalPluginManager.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/macOS/FileTypeSignalPluginManager.swift
@@ -41,7 +41,7 @@ class FileTypeSignalPlugin: _SignalPluginProtocol {
         do {
             let fileUrl = URL(fileURLWithPath: location)
             let signalData = try Data(contentsOf: fileUrl, options: .alwaysMapped)
-            if signalData.count > 0 {
+            if !signalData.isEmpty {
                 let signal = _PluginSignalData(
                     name: config.name,
                     configuration: configuration,

--- a/Sources/DeviceAuthenticator/DeviceSignals/macOS/FileTypeSignalPluginManager.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/macOS/FileTypeSignalPluginManager.swift
@@ -39,9 +39,14 @@ class FileTypeSignalPlugin: _SignalPluginProtocol {
 
     func collectSignals() -> _IntegrationData {
         do {
-            let signal = try String(contentsOfFile: self.location, encoding: .utf8)
-            if let strData = signal.data(using: .utf8) {
-                let signal = _PluginSignalData(name: config.name, configuration: configuration, signal: strData.base64EncodedString(), timeCollected: Int(Date().timeIntervalSince1970))
+            let fileUrl = URL(fileURLWithPath: location)
+            let signalData = try Data(contentsOf: fileUrl, options: .alwaysMapped)
+            if signalData.count > 0 {
+                let signal = _PluginSignalData(
+                    name: config.name,
+                    configuration: configuration,
+                    signal: signalData.base64EncodedString(),
+                    timeCollected: Int(Date().timeIntervalSince1970))
                 return _IntegrationData.signal(signal)
             } else {
                 let error = DeviceAuthenticatorError.genericError("Signal collection failed")


### PR DESCRIPTION

### Problem Analysis (Technical)
Currently, String(contentsOf:) is used which causes double-conversion to and from data. The underlying mechanism is not defined, meaning that using String() when the file is being written to may have unknown consequences.

### Solution (Technical)
Using Data(contentsOf:) allows to skip reading to memory twice and prevents .utf8 conversion. This should improve with consistency and reliability as well as performance.

### Affected Components


### Steps to reproduce:

Actual result:

Expected result:

### Tests
