### PR TITLE
Try to enroll new device in response to 401 invalidToken error from s…

### DIFF
--- a/Tests/DeviceAuthenticatorUnitTests/Mocks/GoldenData.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/Mocks/GoldenData.swift
@@ -487,6 +487,24 @@ class GoldenData {
         let jsonData = try! JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
         return jsonData
     }
+
+    class func invalidTokenError() -> Data {
+        let orgDataJson: String = """
+        {"errorLink":"E0000011","errorSummary":"Invalid token provided","errorCode":"E0000011","errorId":"oaeYckeiQ8aQ124WltauaZB_Q"}
+        """
+        let dict = try! JSONSerialization.jsonObject(with: orgDataJson.data(using: .utf8)!, options: []) as! [String: Any]
+        let jsonData = try! JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+        return jsonData
+    }
+
+    class func deletedDeviceError() -> Data {
+        let orgDataJson: String = """
+        {"errorLink":"E0000153","errorSummary":"Device is deleted","errorCode":"E0000153","errorId":"oaeYckeiQ8aQ124WltauaZB_Q"}
+        """
+        let dict = try! JSONSerialization.jsonObject(with: orgDataJson.data(using: .utf8)!, options: []) as! [String: Any]
+        let jsonData = try! JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+        return jsonData
+    }
 }
 
 class MyAccountTestData {


### PR DESCRIPTION
…erver

### Problem Analysis (Technical)
Server returns 401 Invalid Token for enrollment request with device information from stale device object(old phone).
Some user can't reenroll on new phone within the app and had to reinstall the app in order to enroll new account

### Solution (Technical)
- Do the best effort to restore device information on client/server side
- Retry enrollment request with new device registration in case of 401 Invalid Token
