### PR TITLE
Recreate device object on server side if client fails to build client instance key attestation

### DIFF
--- a/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
+++ b/Sources/DeviceAuthenticator/DeviceSignals/OktaDeviceModelBuilder.swift
@@ -73,18 +73,10 @@ class OktaDeviceModelBuilder {
         return deviceModel
     }
 
-    func buildForUpdateEnrollment(with deviceEnrollment: OktaDeviceEnrollment) -> DeviceSignalsModel {
+    func buildForUpdateEnrollment(with deviceEnrollment: OktaDeviceEnrollment) throws -> DeviceSignalsModel {
         logger.info(eventName: logEventName, message: "Building device model for update enrollment")
         var deviceModel = buildBaseDeviceModel(with: Self.enrollmentSignals)
-        do {
-            try addJWTPart(to: &deviceModel, deviceEnrollment: deviceEnrollment)
-        } catch {
-            // Failed to build device key attestation. Recreate the device object on server side and register new client instance key
-            _ = cryptoManager.delete(keyPairWith: deviceEnrollment.clientInstanceKeyTag)
-            deviceModel = buildForCreateEnrollment(with: deviceEnrollment.clientInstanceKeyTag)
-            deviceModel.id = deviceEnrollment.id
-            deviceModel.clientInstanceId = deviceEnrollment.clientInstanceId
-        }
+        try addJWTPart(to: &deviceModel, deviceEnrollment: deviceEnrollment)
 
         return deviceModel
     }

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -438,7 +438,15 @@ class OktaTransactionEnroll: OktaTransaction {
         let deviceModel: DeviceSignalsModel
         if let deviceEnrollment = deviceEnrollment {
             logger.info(eventName: self.logEventName, message: "Building device model based on existing device object")
-            deviceModel = deviceModelBuilder.buildForUpdateEnrollment(with: deviceEnrollment)
+            do {
+                deviceModel = try deviceModelBuilder.buildForUpdateEnrollment(with: deviceEnrollment)
+            } catch {
+                logger.warning(eventName: self.logEventName, message: "Failed to build client attestation jwt")
+                logger.info(eventName: self.logEventName, message: "Registering new device object")
+                let clientInstanceKeyTag = UUID().uuidString
+                deviceModel = deviceModelBuilder.buildForCreateEnrollment(with: clientInstanceKeyTag)
+                self.clientInstanceKeyTag = clientInstanceKeyTag
+            }
         } else {
             logger.info(eventName: self.logEventName, message: "Registering new device object")
             let clientInstanceKeyTag = UUID().uuidString

--- a/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaDeviceModelBuilderTests.swift
@@ -69,7 +69,7 @@ class OktaDeviceModelBuilderTests: XCTestCase {
         validateDeviceSignals(deviceSignalsModel)
     }
 
-    func testBuildForUpdate() {
+    func testBuildForUpdate() throws {
         let mut = OktaDeviceModelBuilder(orgHost: "https://tenant.okta.com",
                                          applicationConfig: applicationConfig,
                                          requestedSignals: [],
@@ -84,7 +84,7 @@ class OktaDeviceModelBuilderTests: XCTestCase {
                                         useSecureEnclave: false,
                                         useBiometrics: false,
                                         biometricSettings: nil)
-        var deviceSignalsModel = mut.buildForUpdateEnrollment(with: deviceEnrollment)
+        let deviceSignalsModel = try mut.buildForUpdateEnrollment(with: deviceEnrollment)
         XCTAssertEqual(deviceSignalsModel.clientInstanceId, "clientInstanceId")
         XCTAssertEqual(deviceSignalsModel.id, "id")
         XCTAssertNotNil(deviceSignalsModel.deviceAttestation)
@@ -93,10 +93,13 @@ class OktaDeviceModelBuilderTests: XCTestCase {
 
         // Simulate loss of client instance key
         cryptoManager.privateKey = nil
-        deviceSignalsModel = mut.buildForUpdateEnrollment(with: deviceEnrollment)
-        XCTAssertNotNil(deviceSignalsModel.clientInstanceId)
-        XCTAssertNotNil(deviceSignalsModel.id)
-        XCTAssertNil(deviceSignalsModel.deviceAttestation)
+        do {
+            let _ = try mut.buildForUpdateEnrollment(with: deviceEnrollment)
+            XCTFail("Unexpected success")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Encryption operation failed")
+        }
+
         validateDeviceSignals(deviceSignalsModel)
     }
 


### PR DESCRIPTION
### Problem Analysis (Technical)
In backup and restore use cases users are struggling to reenroll since stale data affects enrollment process

### Solution (Technical)
- Don't re-use same device id and clientInstanceId for new device enrollment since in most case it is new device(backup and restore)
- Important piece here is appAuthenticatorId device signal which may give a hint to server whether to create new object or re-use same device

### Affected Components
Enroll transaction

### Tests
Added functional tests
