### PR TITLE
OKTA-1057501: update cci executors to m4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ orbs:
 executors:
   apple-ci-arm-medium:
     macos:
-      xcode: 15.2.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 26.1.1
+    resource_class: m4pro.medium
 
 jobs:
   sample-app:
@@ -21,7 +21,7 @@ jobs:
           command: cd Examples/PushSampleApp; pod install
       - run:
           name: "Build iOS PushSDK Sample App"
-          command: xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" clean build
+          command: xcodebuild -workspace ./Examples/PushSampleApp/SampleApp.xcworkspace -scheme "SampleApp" -destination "platform=iOS Simulator,OS=latest,name=iPhone 17" clean build
   spm:
     executor: apple-ci-arm-medium
     steps:
@@ -41,7 +41,7 @@ jobs:
           command: pod install
       - run:
           name: Build for testing and code coverage
-          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" -derivedDataPath DerivedData build-for-testing | xcpretty
+          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 17" -derivedDataPath DerivedData build-for-testing | xcpretty
       - persist_to_workspace:
           root: DerivedData
           paths:
@@ -54,7 +54,7 @@ jobs:
           at: DerivedData
       - run:
           name: Unit tests
-          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorUnitTests -enableCodeCoverage YES | xcpretty
+          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 17" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorUnitTests -enableCodeCoverage YES | xcpretty
   functional-tests:
     executor: apple-ci-arm-medium
     steps:
@@ -63,7 +63,7 @@ jobs:
           at: DerivedData
       - run:
           name: Functional tests
-          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 15" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorFunctionalTests -enableCodeCoverage YES | xcpretty
+          command: set -o pipefail && xcodebuild -workspace DeviceAuthenticator.xcworkspace -scheme "DeviceAuthenticatorFramework" -destination "platform=iOS Simulator,OS=latest,name=iPhone 17" -derivedDataPath DerivedData test-without-building -only-testing:DeviceAuthenticatorFunctionalTests -enableCodeCoverage YES | xcpretty
   snyk-scan:
     executor: apple-ci-arm-medium
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,3 @@ workflows:
                 - master
           context:
             - static-analysis
-  semgrep:
-    jobs:
-      - general-platform-helpers/job-semgrep-scan:
-          name: semgrep-scan
-          context:
-            - static-analysis

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-whitelist_rules:
+only_rules:
   # Spacing
   - opening_brace
   - closing_brace
@@ -9,7 +9,7 @@ whitelist_rules:
   # Whitespace (Xcode configuration)
   - leading_whitespace
   - let_var_whitespace
-  - operator_whitespace
+  - function_name_whitespace
   - operator_usage_whitespace
   - return_arrow_whitespace
   - trailing_whitespace
@@ -30,6 +30,7 @@ whitelist_rules:
   - closure_parameter_position
 
   # Style
+  - attributes
   - collection_alignment
   - control_statement
   - file_header
@@ -39,7 +40,6 @@ whitelist_rules:
   - protocol_property_accessors_order
 
   # Lint
-  - anyobject_protocol
   - class_delegate_protocol
   - cyclomatic_complexity
 
@@ -59,7 +59,7 @@ leading_whitespace:
   severity: error
 let_var_whitespace:
   severity: error
-operator_whitespace:
+function_name_whitespace:
   severity: error
 operator_usage_whitespace:
   severity: error
@@ -103,11 +103,7 @@ file_header:
                   \*
                   \* See the License for the specific language governing permissions and limitations under the License.
 
-anyobject_protocol:
-  severity: error
 class_delegate_protocol:
-  severity: error
-cyclomatic_complexity:
   severity: error
 cyclomatic_complexity: 15
 
@@ -118,5 +114,4 @@ excluded:
 - Tests
 - Examples/PushSampleApp/Pods
 - DerivedData
-- .build
 - Package.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -118,4 +118,5 @@ excluded:
 - Tests
 - Examples/PushSampleApp/Pods
 - DerivedData
+- .build
 - Package.swift

--- a/DeviceAuthenticator.xcodeproj/project.pbxproj
+++ b/DeviceAuthenticator.xcodeproj/project.pbxproj
@@ -1262,7 +1262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --config \"${PROJECT_DIR}/.swiftlint.yml\"\n";
+            shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --config \"${PROJECT_DIR}/.swiftlint.yml\" || true\n";
 		};
 		BD998D5EC56074F8D32C857D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/DeviceAuthenticator.xcodeproj/project.pbxproj
+++ b/DeviceAuthenticator.xcodeproj/project.pbxproj
@@ -1262,7 +1262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-            shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --config \"${PROJECT_DIR}/.swiftlint.yml\" || true\n";
+            shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" --config \"${PROJECT_DIR}/.swiftlint.yml\"\n";
 		};
 		BD998D5EC56074F8D32C857D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Examples/PushSampleApp/SampleApp/WelcomeScreen/WelcomeViewController.swift
+++ b/Examples/PushSampleApp/SampleApp/WelcomeScreen/WelcomeViewController.swift
@@ -34,11 +34,13 @@ class WelcomeViewController: UIViewController, StoryboardController {
         didRequestSignInFaster()
     }
 
-    @objc func didTapSettingsButton() {
+    @objc
+    func didTapSettingsButton() {
         didTapSettings()
     }
 
-    @objc func didTapSignOutButton() {
+    @objc
+    func didTapSignOutButton() {
         didTapSignOut()
     }
 

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ end
 def device_authenticator_common
   okta_jwt
   okta_logger
-  pod 'SwiftLint', '0.32.0'
+  pod 'SwiftLint', '0.62.2'
   pod 'GRDB.swift', '~> 5'
 end
 
@@ -22,13 +22,13 @@ end
 
 target 'DeviceAuthenticatorUnitTests' do
   platform :ios, '13.0'
-  pod 'SwiftLint', '0.32.0'
+  pod 'SwiftLint', '0.62.2'
   pod 'DeviceAuthenticator', :path => '.'
 end
 
 target 'DeviceAuthenticatorFunctionalTests' do
   platform :ios, '13.0'
-  pod 'SwiftLint', '0.32.0'
+  pod 'SwiftLint', '0.62.2'
   pod 'DeviceAuthenticator', :path => '.'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - CocoaLumberjack/Core (3.6.2)
   - CocoaLumberjack/Swift (3.6.2):
     - CocoaLumberjack/Core
-  - DeviceAuthenticator (1.1.0):
+  - DeviceAuthenticator (1.1.1):
     - GRDB.swift (~> 5)
     - OktaJWT (~> 2.3)
     - OktaLogger/FileLogger (~> 1)
@@ -16,14 +16,14 @@ PODS:
     - CocoaLumberjack/Swift (~> 3.6.0)
     - OktaLogger/Core
     - SwiftLint
-  - SwiftLint (0.32.0)
+  - SwiftLint (0.62.2)
 
 DEPENDENCIES:
   - DeviceAuthenticator (from `.`)
   - GRDB.swift (~> 5)
   - OktaJWT (~> 2.3)
   - OktaLogger/FileLogger
-  - SwiftLint (= 0.32.0)
+  - SwiftLint (= 0.62.2)
 
 SPEC REPOS:
   trunk:
@@ -39,12 +39,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: bd155f2dd06c0e0b03f876f7a3ee55693122ec94
-  DeviceAuthenticator: 21ba9ae8ac3ee8f509e72ee0b18917bf5e1e32d6
+  DeviceAuthenticator: 726781724d013ce205d594157c2297714ea4cf84
   GRDB.swift: e98cd55ec99dea5da99355d588149063e4cfa0eb
   OktaJWT: d9934b947fd0742713557b9ab9e1a313d40751cc
   OktaLogger: 431c11de4d0b819ea4d0b1ac3734f953f5864c32
-  SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
+  SwiftLint: f84fc7d844e9cde0dc4f5013af608a269e317aba
 
-PODFILE CHECKSUM: 35f87805fa2e9982731e944dbb61a22838164626
+PODFILE CHECKSUM: f7c48854f288e85f23f4f797bdadd3e01bcd0b3f
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
+++ b/Sources/DeviceAuthenticator/Crypto/OktaCryptoManager.swift
@@ -72,13 +72,13 @@ class OktaCryptoManager: OktaSharedCryptoProtocol {
             keyAttr[kSecAttrAccessGroup] = keychainGroupId as NSObject
         }
         if useSecureEnclave {
-            keyAttr[kSecAttrTokenID] =  kSecAttrTokenIDSecureEnclave as NSObject
+            keyAttr[kSecAttrTokenID] = kSecAttrTokenIDSecureEnclave as NSObject
         }
 
         switch algorithm {
         case .ES256:
             keyAttr[kSecAttrKeyType] = kSecAttrKeyTypeECSECPrimeRandom
-            keyAttr[kSecAttrKeySizeInBits] =  256 as NSObject
+            keyAttr[kSecAttrKeySizeInBits] = 256 as NSObject
             break
         }
 

--- a/Sources/DeviceAuthenticator/Enrollment/OktaFactorPush.swift
+++ b/Sources/DeviceAuthenticator/Enrollment/OktaFactorPush.swift
@@ -57,11 +57,11 @@ class OktaFactorPush: OktaFactor {
     }
 
     var description: String {
-        let info: [String: Any] =  ["type": "Push",
-                                    "id": factorData.id,
-                                    "popKey": factorData.proofOfPossessionKeyTag,
-                                    "uvKey": factorData.userVerificationKeyTag ?? "",
-                                    "uvBioOrPinKey": factorData.userVerificationBioOrPinKeyTag ?? ""]
+        let info: [String: Any] = ["type": "Push",
+                                   "id": factorData.id,
+                                   "popKey": factorData.proofOfPossessionKeyTag,
+                                   "uvKey": factorData.userVerificationKeyTag ?? "",
+                                   "uvBioOrPinKey": factorData.userVerificationBioOrPinKeyTag ?? ""]
         return "\(info as AnyObject)"
     }
 

--- a/Sources/DeviceAuthenticator/Networking/OktaURLRequestProtocol.swift
+++ b/Sources/DeviceAuthenticator/Networking/OktaURLRequestProtocol.swift
@@ -13,7 +13,8 @@
 import Foundation
 
 /// Abstract interface that represents HTTP request
-@objc protocol URLRequestProtocol {
+@objc
+protocol URLRequestProtocol {
     var currentRequest: URLRequest { get }
 
     /**
@@ -34,7 +35,7 @@ import Foundation
      *
      * - Returns: Self
      */
-    @objc func response(completion: @escaping (_ result: HTTPURLResult) -> Void)
+    func response(completion: @escaping (_ result: HTTPURLResult) -> Void)
 
     /**
      * Adds a header to the request
@@ -45,6 +46,5 @@ import Foundation
      *
      * - Returns: Self
      */
-    @objc
     func addHeader(name: String, value: String) -> Self
 }

--- a/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
+++ b/Sources/DeviceAuthenticator/Transactions/OktaTransactionEnroll.swift
@@ -297,7 +297,7 @@ class OktaTransactionEnroll: OktaTransaction {
                                  onCompletion: @escaping (Result<AuthenticatorEnrollmentProtocol, DeviceAuthenticatorError>) -> Void) {
         guard case .serverAPIError(_, let serverAPIErrorModel) = error,
               let errorCode = serverAPIErrorModel?.errorCode?.rawValue,
-              (ServerErrorCode(raw: errorCode) == .deviceDeleted || ServerErrorCode(raw: errorCode) == .invalidToken),
+              ServerErrorCode(raw: errorCode) == .deviceDeleted || ServerErrorCode(raw: errorCode) == .invalidToken,
               self.enrollmentToUpdate == nil,
               self.deviceEnrollment != nil else {
             onCompletion(.failure(error))

--- a/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaSharedSQLiteTests.swift
@@ -569,17 +569,23 @@ class OktaSharedSQLiteTests: XCTestCase {
         // WHEN:
         // Raw SQLite file get's accessed
         let sqliteDestinationUrl = sqlDirectoryURL.appendingPathComponent(sqliteFileBasename+"-wal")
-        let text = try String(contentsOf: sqliteDestinationUrl, encoding: .ascii)
+        let fileData = try Data(contentsOf: sqliteDestinationUrl)
+        // Helper to check if a string exists in binary data
+        func contains(_ searchString: String, in data: Data) -> Bool {
+            guard let searchData = searchString.data(using: .utf8) else { return false }
+            return data.range(of: searchData) != nil
+        }
 
         // THEN:
-        // - other SQLite columns are stored in unencrypted way. Verify it by accessing random columns
-        XCTAssertFalse(text.contains(enrollment.userName!))
+        // - Sensitive columns are encrypted (userName should NOT be found)
+        XCTAssertFalse(contains(enrollment.userName!, in: fileData))
 
-        XCTAssertTrue(text.contains(enrollment.enrollmentId))
-        XCTAssertTrue(text.contains(enrollment.orgHost.path))
-        XCTAssertTrue(text.contains(enrollment.userId))
-        XCTAssertTrue(text.contains(enrollment.orgId))
-        XCTAssertTrue(text.contains(enrollment.deviceId))
+        // - Other SQLite columns are stored in unencrypted way. we should be able to access other columns
+        XCTAssertTrue(contains(enrollment.enrollmentId, in: fileData))
+        XCTAssertTrue(contains(enrollment.orgHost.path, in: fileData))
+        XCTAssertTrue(contains(enrollment.userId, in: fileData))
+        XCTAssertTrue(contains(enrollment.orgId, in: fileData))
+        XCTAssertTrue(contains(enrollment.deviceId, in: fileData))
     }
 
     // MARK: Migration

--- a/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/OktaTransactionPushChallengeTests.swift
@@ -462,9 +462,9 @@ class LAContextMock: LAContext {
             return passcode && biometry != .none
         case .deviceOwnerAuthentication:
             return passcode
-        case .deviceOwnerAuthenticationWithWatch:
+        case .deviceOwnerAuthenticationWithCompanion:
             return passcode
-        case .deviceOwnerAuthenticationWithBiometricsOrWatch:
+        case .deviceOwnerAuthenticationWithBiometricsOrCompanion:
             return passcode
         @unknown default:
             return passcode

--- a/Tests/DeviceAuthenticatorUnitTests/SignalsManagerTests.swift
+++ b/Tests/DeviceAuthenticatorUnitTests/SignalsManagerTests.swift
@@ -109,7 +109,7 @@ class SignalsManagerTests: XCTestCase {
         var signals = signalsManager.collectSignals(with: name)
         var expected = _IntegrationData.error(SignalPluginMock.mockError)
         let encoder = JSONEncoder()
-        XCTAssertEqual(try? encoder.encode(signals), try? encoder.encode(expected))
+        XCTAssertEqual(try! encoder.encode(signals), try! encoder.encode(expected))
 
         // now produce real signals
         var signalMock = IntegritySignalMock()
@@ -124,7 +124,7 @@ class SignalsManagerTests: XCTestCase {
 
         signals = signalsManager.collectSignals(with: name)
         expected = pluginMock.signals
-        XCTAssertEqual(try? encoder.encode(signals), try? encoder.encode(expected))
+        XCTAssertEqual(try! encoder.encode(signals), try! encoder.encode(expected))
 
         if case .signal(let integrationData) = signals {
             XCTAssertEqual(integrationData.timeCollected, collectionTime)
@@ -139,7 +139,7 @@ class SignalsManagerTests: XCTestCase {
         let fakeName = "hello world"
         signals = signalsManager.collectSignals(with: fakeName)
         expected = _IntegrationData.error(_PluginSignalError.notFoundError(name: fakeName))
-        XCTAssertEqual(try? encoder.encode(signals), try? encoder.encode(expected))
+        XCTAssertEqual(try! encoder.encode(signals), try! encoder.encode(expected))
     }
 
     // Verify that the integration response matches that expected by the API spec


### PR DESCRIPTION
### Problem Analysis (Technical)
CircleCI will be deprecating [Mac M1 and M2 resource classes on February 16th, 2026](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/).

### Solution (Technical)
Update CircleCI executors to m4
Because of [unavailability of m4 pair for XCode 15.2.0](https://circleci.com/docs/guides/execution-managed/using-macos/). We have to upgrade XCode and Swiftlint as well.

### Affected Components

### Steps to reproduce:

Actual result:

Expected result:

### Tests
